### PR TITLE
feat: show datetime tooltip faster.

### DIFF
--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -20,7 +20,7 @@
   <div class="flex flex-col gap-2 text-white">
     <section class="flex gap-2">
       <h5 class="font-bold">{event.user.handle}</h5>
-      <Tooltip.Root openDelay={1000}>
+      <Tooltip.Root openDelay={300}>
         <Tooltip.Trigger>
           <time class="text-zinc-400 cursor-context-menu">
             {formatDistanceToNowStrict(new Date(event.timestamp))}


### PR DESCRIPTION
I felt like I has having to "wait around" for tooltip to load. This value feels like a good mix of quickness without accidentally triggering. This is subjective so I understand if you want to keep current value.