### PR TITLE
feat: threads interface v1

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -32,6 +32,7 @@
     "npm:sanitize-html@^2.14.0": "2.14.0",
     "npm:svelte-boring-avatars@^1.2.6": "1.2.6",
     "npm:svelte-check@4": "4.1.4_svelte@5.19.3__acorn@8.14.0_typescript@5.7.3",
+    "npm:svelte-french-toast@^1.2.0": "1.2.0_svelte@4.2.19",
     "npm:svelte@^5.19.3": "5.19.3_acorn@8.14.0",
     "npm:tailwindcss@4": "4.0.0",
     "npm:tweetnacl@^1.0.3": "1.0.3",
@@ -1843,6 +1844,19 @@
         "typescript"
       ]
     },
+    "svelte-french-toast@1.2.0_svelte@4.2.19": {
+      "integrity": "sha512-5PW+6RFX3xQPbR44CngYAP1Sd9oCq9P2FOox4FZffzJuZI2mHOB7q5gJBVnOiLF5y3moVGZ7u2bYt7+yPAgcEQ==",
+      "dependencies": [
+        "svelte@4.2.19",
+        "svelte-writable-derived"
+      ]
+    },
+    "svelte-writable-derived@3.1.1_svelte@4.2.19": {
+      "integrity": "sha512-w4LR6/bYZEuCs7SGr+M54oipk/UQKtiMadyOhW0PTwAtJ/Ai12QS77sLngEcfBx2q4H8ZBQucc9ktSA5sUGZWw==",
+      "dependencies": [
+        "svelte@4.2.19"
+      ]
+    },
     "svelte@4.2.19": {
       "integrity": "sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==",
       "dependencies": [
@@ -2128,6 +2142,7 @@
         "npm:sanitize-html@^2.14.0",
         "npm:svelte-boring-avatars@^1.2.6",
         "npm:svelte-check@4",
+        "npm:svelte-french-toast@^1.2.0",
         "npm:svelte@^5.19.3",
         "npm:tailwindcss@4",
         "npm:tweetnacl@^1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/vite": "^4.0.0",
     "bits-ui": "^0.22.0",
     "svelte-boring-avatars": "^1.2.6",
+    "svelte-french-toast": "^1.2.0",
     "ulidx": "^2.4.1"
   },
   "devDependencies": {

--- a/src/lib/components/ThreadRow.svelte
+++ b/src/lib/components/ThreadRow.svelte
@@ -3,8 +3,17 @@
   import type { Ulid, Thread } from "$lib/schemas/types";
   import { decodeTime } from "ulidx";
   import { formatDistanceToNowStrict } from "date-fns";
+  import { Button, Dialog, Separator } from "bits-ui";
+  import { fade } from "svelte/transition";
 
-  let { id, thread, onclick }: { id: Ulid, thread: Thread, onclick: () => void } = $props();
+  type Props = {
+    id: Ulid;
+    thread: Thread;
+    onclick: () => void;
+    onclickDelete: () => void;
+  }
+
+  let { id, thread, onclick, onclickDelete }: Props = $props();
   let latest = $derived.by(() => {
     let allTime: number[] = [];
     for (const id of thread.timeline) {
@@ -13,17 +22,52 @@
     allTime.sort();
     return new Date(allTime[allTime.length-1]);
   });
-
-  $inspect({ latest })
 </script>
 
-<button {id} {onclick} class="border border-white rounded cursor-pointer text-white flex w-full justify-between p-4 hover:bg-white/5 transition-all duration-75">
-  <div class="flex gap-4 items-center">
+<div {id} class="border border-white rounded text-white flex w-full justify-between p-4 hover:bg-white/5 transition-all duration-75">
+  <Button.Root {onclick} class="flex gap-4 items-center grow cursor-pointer">
     <h1 class="text-xl font-semibold">{thread.title}</h1>
     <time class="text-sm text-gray-300">Latest: {formatDistanceToNowStrict(latest)} ago</time>
+  </Button.Root>
+  <div class="flex gap-4 items-center">
+    <p class="flex gap-2 items-center">
+      {thread.timeline.length}
+      <Icon icon="tabler:message" />
+    </p>
+    <Dialog.Root> 
+      <Dialog.Trigger class="hover:scale-105 active:scale-95 transition-all duration-150 cursor-pointer">
+        <Icon icon="tabler:trash" color="red" />
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          transition={fade}
+          transitionConfig={{ duration: 150 }}
+          class="fixed inset-0 z-50 bg-black/80"
+        />
+        <Dialog.Content
+          class="fixed p-5 flex flex-col text-white gap-4 w-dvw max-w-(--breakpoint-sm) left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%] rounded-lg border bg-purple-950"
+        >
+          <Dialog.Title
+            class="text-bold font-bold text-xl flex items-center justify-center gap-4"
+          >
+            <Icon icon="ri:alarm-warning-fill" color="red" class="text-2xl" />
+            <span> Delete Thread </span>
+            <Icon icon="ri:alarm-warning-fill" color="red" class="text-2xl" />
+          </Dialog.Title>
+          <Separator.Root class="border border-white" />
+          <div class="flex flex-col items-center gap-4">
+            <p>
+              The thread will be unrecoverable once deleted.
+            </p>
+            <Button.Root
+              onclick={onclickDelete}
+              class="flex items-center gap-3 px-4 py-2 max-w-[20em] bg-red-600 text-white rounded-lg hover:scale-[102%] active:scale-95 transition-all duration-150"
+            >
+              Confirm Delete
+            </Button.Root>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   </div>
-  <p class="flex gap-2 items-center">
-    {thread.timeline.length}
-    <Icon icon="tabler:message" />
-  </p>
-</button>
+</div>

--- a/src/lib/components/ThreadRow.svelte
+++ b/src/lib/components/ThreadRow.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import Icon from "@iconify/svelte";
+  import type { Ulid, Thread } from "$lib/schemas/types";
+
+  let { id, thread, onclick }: { id: Ulid, thread: Thread, onclick: () => void } = $props();
+</script>
+
+<button {id} {onclick} class="text-white flex w-full justify-between p-4 hover:bg-white/5 transition-all duration-75">
+  <h1>{thread.title}</h1>
+  <p class="flex gap-2 items-center">
+    {thread.timeline.length}
+    <Icon icon="tabler:message" />
+  </p>
+</button>

--- a/src/lib/components/ThreadRow.svelte
+++ b/src/lib/components/ThreadRow.svelte
@@ -5,8 +5,8 @@
   let { id, thread, onclick }: { id: Ulid, thread: Thread, onclick: () => void } = $props();
 </script>
 
-<button {id} {onclick} class="text-white flex w-full justify-between p-4 hover:bg-white/5 transition-all duration-75">
-  <h1>{thread.title}</h1>
+<button {id} {onclick} class="cursor-pointer text-white flex w-full justify-between p-4 hover:bg-white/5 transition-all duration-75">
+  <h1 class="text-xl font-semibold">{thread.title}</h1>
   <p class="flex gap-2 items-center">
     {thread.timeline.length}
     <Icon icon="tabler:message" />

--- a/src/lib/components/ThreadRow.svelte
+++ b/src/lib/components/ThreadRow.svelte
@@ -1,12 +1,27 @@
 <script lang="ts">
   import Icon from "@iconify/svelte";
   import type { Ulid, Thread } from "$lib/schemas/types";
+  import { decodeTime } from "ulidx";
+  import { formatDistanceToNowStrict } from "date-fns";
 
   let { id, thread, onclick }: { id: Ulid, thread: Thread, onclick: () => void } = $props();
+  let latest = $derived.by(() => {
+    let allTime: number[] = [];
+    for (const id of thread.timeline) {
+      allTime.push(decodeTime(id));
+    }
+    allTime.sort();
+    return new Date(allTime[allTime.length-1]);
+  });
+
+  $inspect({ latest })
 </script>
 
-<button {id} {onclick} class="cursor-pointer text-white flex w-full justify-between p-4 hover:bg-white/5 transition-all duration-75">
-  <h1 class="text-xl font-semibold">{thread.title}</h1>
+<button {id} {onclick} class="border border-white rounded cursor-pointer text-white flex w-full justify-between p-4 hover:bg-white/5 transition-all duration-75">
+  <div class="flex gap-4 items-center">
+    <h1 class="text-xl font-semibold">{thread.title}</h1>
+    <time class="text-sm text-gray-300">Latest: {formatDistanceToNowStrict(latest)} ago</time>
+  </div>
   <p class="flex gap-2 items-center">
     {thread.timeline.length}
     <Icon icon="tabler:message" />

--- a/src/lib/components/ThreadRow.svelte
+++ b/src/lib/components/ThreadRow.svelte
@@ -32,11 +32,11 @@
   <div class="flex gap-4 items-center">
     <p class="flex gap-2 items-center">
       {thread.timeline.length}
-      <Icon icon="tabler:message" />
+      <Icon icon="tabler:message" class="text-2xl" />
     </p>
     <Dialog.Root> 
       <Dialog.Trigger class="hover:scale-105 active:scale-95 transition-all duration-150 cursor-pointer">
-        <Icon icon="tabler:trash" color="red" />
+        <Icon icon="tabler:trash" color="red" class="text-2xl" />
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Overlay

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -10,6 +10,7 @@
   import { goto } from "$app/navigation";
   import { RoomyPdsStorageAdapter } from "$lib/autodoc-storage";
   import { page } from "$app/state";
+  import { Toaster } from "svelte-french-toast";
 
   let { children } = $props();
 
@@ -58,6 +59,7 @@
 
 <!-- Container -->
 <div class="flex gap-4 p-4 bg-violet-900 w-screen h-screen">
+  <Toaster />
   <!-- Server Bar -->
   <aside
     class="flex flex-col justify-between w-20 h-full bg-violet-950 rounded-lg px-4 py-8 items-center"

--- a/src/routes/(app)/dm/[did]/+page.svelte
+++ b/src/routes/(app)/dm/[did]/+page.svelte
@@ -6,10 +6,10 @@
   import { page } from "$app/state";
   import { user } from "$lib/user.svelte";
   import { setContext, untrack } from "svelte";
-  import { Avatar, Button, Popover, Tabs, Toggle } from "bits-ui";
+  import { Avatar, Button, Dialog, Popover, Separator, Tabs, Toggle } from "bits-ui";
   import { AvatarBeam } from "svelte-boring-avatars";
   import Icon from "@iconify/svelte";
-  import { fly } from "svelte/transition";
+  import { fade, fly } from "svelte/transition";
   import { ulid } from "ulidx";
   import ThreadRow from "$lib/components/ThreadRow.svelte";
   import { goto } from "$app/navigation";
@@ -108,6 +108,8 @@
     channel.change((doc) => {
       delete doc.threads[id]
     });
+
+    goto(page.url.pathname);
   }
 </script>
 
@@ -247,13 +249,50 @@
   {#if tab === "threads"}
     {#if currentThread} 
       <section class="flex flex-col gap-4 items-start">
-        <button 
-          onclick={() => goto(page.url.pathname)}
-          class="flex gap-2 items-center text-white cursor-pointer hover:scale-105 transitiona-all duration-150" 
-        > 
-          <Icon icon="uil:left" />
-          Back
-        </button>
+        <menu class="px-4 py-2 flex w-full justify-between">
+          <Button.Root
+            onclick={() => goto(page.url.pathname)}
+            class="flex gap-2 items-center text-white cursor-pointer hover:scale-105 transitiona-all duration-150" 
+          > 
+            <Icon icon="uil:left" />
+            Back
+          </Button.Root>
+          <Dialog.Root> 
+            <Dialog.Trigger class="hover:scale-105 active:scale-95 transition-all duration-150 cursor-pointer">
+              <Icon icon="tabler:trash" color="red" class="text-2xl" />
+            </Dialog.Trigger>
+            <Dialog.Portal>
+              <Dialog.Overlay
+                transition={fade}
+                transitionConfig={{ duration: 150 }}
+                class="fixed inset-0 z-50 bg-black/80"
+              />
+              <Dialog.Content
+                class="fixed p-5 flex flex-col text-white gap-4 w-dvw max-w-(--breakpoint-sm) left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%] rounded-lg border bg-purple-950"
+              >
+                <Dialog.Title
+                  class="text-bold font-bold text-xl flex items-center justify-center gap-4"
+                >
+                  <Icon icon="ri:alarm-warning-fill" color="red" class="text-2xl" />
+                  <span> Delete Thread </span>
+                  <Icon icon="ri:alarm-warning-fill" color="red" class="text-2xl" />
+                </Dialog.Title>
+                <Separator.Root class="border border-white" />
+                <div class="flex flex-col items-center gap-4">
+                  <p>
+                    The thread will be unrecoverable once deleted.
+                  </p>
+                  <Button.Root
+                    onclick={() => deleteThread(page.url.searchParams.get("thread")!)}
+                    class="flex items-center gap-3 px-4 py-2 max-w-[20em] bg-red-600 text-white rounded-lg hover:scale-[102%] active:scale-95 transition-all duration-150"
+                  >
+                    Confirm Delete
+                  </Button.Root>
+                </div>
+              </Dialog.Content>
+            </Dialog.Portal>
+          </Dialog.Root>
+        </menu>
         {#each currentThread.timeline as id}
           <ChatMessage {id} message={channel.view.messages[id]} />
         {/each}

--- a/src/routes/(app)/dm/[did]/+page.svelte
+++ b/src/routes/(app)/dm/[did]/+page.svelte
@@ -101,6 +101,14 @@
 
     messageInput = "";
   }
+
+  function deleteThread(id: Ulid) {
+    if (!channel) return;
+
+    channel.change((doc) => {
+      delete doc.threads[id]
+    });
+  }
 </script>
 
 <header class="flex flex-none items-center justify-between border-b-1 pb-4">
@@ -252,7 +260,12 @@
     {:else}
       <ul class="overflow-y-auto px-2 gap-3 flex flex-col">
         {#each Object.entries(channel.view.threads) as [id, thread] (id)}
-          <ThreadRow {id} {thread} onclick={() => goto(`?thread=${id}`)} />
+          <ThreadRow 
+            {id} 
+            {thread} 
+            onclick={() => goto(`?thread=${id}`)} 
+            onclickDelete={() => deleteThread(id)} 
+          />
         {/each}
       </ul>
     {/if}

--- a/src/routes/(app)/dm/[did]/+page.svelte
+++ b/src/routes/(app)/dm/[did]/+page.svelte
@@ -14,6 +14,7 @@
   import ThreadRow from "$lib/components/ThreadRow.svelte";
   import { goto } from "$app/navigation";
   import ChatMessage from "$lib/components/ChatMessage.svelte";
+  import toast from "svelte-french-toast";
 
   let tab = $state("chat");
   let channel: Autodoc<Channel> | undefined = $derived(g.dms[page.params.did]);
@@ -81,6 +82,7 @@
 
     threadTitleInput = "";
     isThreading.value = false;
+    toast.success("Thread created", { position: "bottom-end" })
   }
 
   function sendMessage(e: SubmitEvent) {
@@ -109,6 +111,7 @@
       delete doc.threads[id]
     });
 
+    toast.success("Thread deleted", { position: "bottom-end" });
     goto(page.url.pathname);
   }
 </script>

--- a/src/routes/(app)/dm/[did]/+page.svelte
+++ b/src/routes/(app)/dm/[did]/+page.svelte
@@ -202,9 +202,10 @@
     {/if}
     <Toggle.Root
       bind:pressed={isThreading.value}
+      disabled={tab !== "chat"}
       class={`p-2 ${isThreading.value && "bg-white/10"} hover:scale-105 active:scale-95 transition-all duration-150 rounded`}
     >
-      <Icon icon="tabler:needle-thread" color="white" class="text-2xl" />
+      <Icon icon="tabler:needle-thread" color={tab !== "chat" ? "gray" : "white"} class="text-2xl" />
     </Toggle.Root>
     <Button.Root
       title="Copy invite link"

--- a/src/routes/(app)/dm/[did]/+page.svelte
+++ b/src/routes/(app)/dm/[did]/+page.svelte
@@ -161,12 +161,12 @@
     </Tabs.List>
   </Tabs.Root>
 
-  <menu class="flex items-center">
+  <menu class="flex items-center gap-2">
     {#if isThreading.value}
       <div in:fly>
         <Popover.Root>
           <Popover.Trigger
-            class="mx-2 px-4 py-2 rounded bg-violet-800 text-white"
+            class="cursor-pointer mx-2 px-4 py-2 rounded bg-violet-800 text-white"
           >
             Create Thread
           </Popover.Trigger>
@@ -205,13 +205,13 @@
     <Toggle.Root
       bind:pressed={isThreading.value}
       disabled={tab !== "chat"}
-      class={`p-2 ${isThreading.value && "bg-white/10"} hover:scale-105 active:scale-95 transition-all duration-150 rounded`}
+      class={`p-2 ${isThreading.value && "bg-white/10"} cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150 rounded`}
     >
       <Icon icon="tabler:needle-thread" color={tab !== "chat" ? "gray" : "white"} class="text-2xl" />
     </Toggle.Root>
     <Button.Root
       title="Copy invite link"
-      class="hover:scale-105 active:scale-95 transition-all duration-150"
+      class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150"
       onclick={() => {
         navigator.clipboard.writeText(
           `${page.url.protocol}//${page.url.host}/invite/dm/${user.agent?.assertDid}`,
@@ -225,7 +225,7 @@
       />
     </Button.Root>
     <Button.Root
-      class="p-2 hover:scale-105 active:scale-95 transition-all duration-150"
+      class="p-2 cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150"
     >
       <Icon icon="basil:settings-alt-solid" color="white" class="text-2xl" />
     </Button.Root>

--- a/src/routes/(app)/dm/[did]/+page.svelte
+++ b/src/routes/(app)/dm/[did]/+page.svelte
@@ -111,24 +111,20 @@
         <AvatarBeam name={info?.name} />
       </Avatar.Fallback>
     </Avatar.Root>
-    <h4 class="text-white text-lg font-bold">
-      {info?.name}
-    </h4>
-    <Button.Root
-      title="Copy invite link"
-      class="p-2 hover:scale-105 active:scale-95 transition-all duration-150"
-      onclick={() => {
-        navigator.clipboard.writeText(
-          `${page.url.protocol}//${page.url.host}/invite/dm/${user.agent?.assertDid}`,
-        );
-      }}
-    >
-      <Icon
-        icon="icon-park-outline:copy-link"
-        color="white"
-        font-size="1.75em"
-      />
-    </Button.Root>
+
+    <span class="flex gap-2 items-center">
+      <h4 class="text-white text-lg font-bold">
+        {info?.name}
+      </h4>
+      {#if currentThread}
+        <Icon icon="mingcute:right-line" color="white" />
+        <Icon icon="lucide-lab:reel-thread" color="white" />
+        <h5 class="text-white text-lg font-bold">
+          {currentThread.title}
+        </h5>
+      {/if}
+    </span>
+
   </div>
 
   <Tabs.Root bind:value={tab}>
@@ -203,6 +199,21 @@
       <Icon icon="tabler:needle-thread" color="white" class="text-2xl" />
     </Toggle.Root>
     <Button.Root
+      title="Copy invite link"
+      class="hover:scale-105 active:scale-95 transition-all duration-150"
+      onclick={() => {
+        navigator.clipboard.writeText(
+          `${page.url.protocol}//${page.url.host}/invite/dm/${user.agent?.assertDid}`,
+        );
+      }}
+    >
+      <Icon
+        icon="icon-park-outline:copy-link"
+        color="white"
+        class="text-2xl"
+      />
+    </Button.Root>
+    <Button.Root
       class="p-2 hover:scale-105 active:scale-95 transition-all duration-150"
     >
       <Icon icon="basil:settings-alt-solid" color="white" class="text-2xl" />
@@ -226,8 +237,12 @@
   <!-- TODO: Render Threads -->
   {#if tab === "threads"}
     {#if currentThread} 
-      <section class="flex flex-col gap-4">
-        <button class="text-white" onclick={() => goto(page.url.pathname)}> 
+      <section class="flex flex-col gap-4 items-start">
+        <button 
+          onclick={() => goto(page.url.pathname)}
+          class="flex gap-2 items-center text-white cursor-pointer hover:scale-105 transitiona-all duration-150" 
+        > 
+          <Icon icon="uil:left" />
           Back
         </button>
         {#each currentThread.timeline as id}


### PR DESCRIPTION
Implements new UI for the thread tab, where each are a row that on click will add a `?thread=<ulid>` search parameter to the DM URL. The tab will then render all the messages in the thread.

Each row has the title, the latest message's time in the thread, number of the messages in the thread, and a delete button that opens a dialog to confirm deletion.

Closes #40 
Closes #33 

https://github.com/user-attachments/assets/0299c487-6748-4e98-bc3b-dc42d0439410