### PR TITLE
feat: reply UX v1

### DIFF
--- a/src/lib/components/ChatArea.svelte
+++ b/src/lib/components/ChatArea.svelte
@@ -2,7 +2,7 @@
   import { ScrollArea } from "bits-ui";
   import ChatMessage from "./ChatMessage.svelte";
   import type { Autodoc } from "$lib/autodoc/peer";
-  import type { Channel } from "$lib/schemas/types";
+  import type { Channel, Ulid } from "$lib/schemas/types";
   import { setContext } from "svelte";
 
   let { channel }: { channel: Autodoc<Channel> } = $props();

--- a/src/lib/components/ChatArea.svelte
+++ b/src/lib/components/ChatArea.svelte
@@ -22,7 +22,7 @@
 <ScrollArea.Root>
   <ScrollArea.Viewport bind:el={viewport} class="w-full h-full">
     <ScrollArea.Content>
-      <ol class="flex flex-col">
+      <ol class="flex flex-col gap-4">
         {#each channel.view.timeline as id (id)}
           <ChatMessage {id} message={channel.view.messages[id]} />
         {/each}

--- a/src/lib/components/ChatArea.svelte
+++ b/src/lib/components/ChatArea.svelte
@@ -2,11 +2,9 @@
   import { ScrollArea } from "bits-ui";
   import ChatMessage from "./ChatMessage.svelte";
   import type { Autodoc } from "$lib/autodoc/peer";
-  import type { Channel, Ulid } from "$lib/schemas/types";
-  import { setContext } from "svelte";
+  import type { Channel } from "$lib/schemas/types";
 
   let { channel }: { channel: Autodoc<Channel> } = $props();
-  setContext("messages", channel.view.messages);
 
   // ScrollArea
   let viewport: HTMLDivElement | undefined = $state();
@@ -24,7 +22,7 @@
     <ScrollArea.Content>
       <ol class="flex flex-col gap-4">
         {#each channel.view.timeline as id (id)}
-          <ChatMessage {id} message={channel.view.messages[id]} />
+          <ChatMessage {id} {channel} />
         {/each}
       </ol>
     </ScrollArea.Content>

--- a/src/lib/components/ChatArea.svelte
+++ b/src/lib/components/ChatArea.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { ScrollArea } from "bits-ui";
   import ChatMessage from "./ChatMessage.svelte";
-  import type { Autodoc } from "$lib/autodoc.svelte";
+  import type { Autodoc } from "$lib/autodoc/peer";
   import type { Channel } from "$lib/schemas/types";
+  import { setContext } from "svelte";
 
   let { channel }: { channel: Autodoc<Channel> } = $props();
+  setContext("messages", channel.view.messages);
 
   // ScrollArea
   let viewport: HTMLDivElement | undefined = $state();

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -14,7 +14,7 @@
   let profile = getProfile(message.author);
   let messages = getContext("messages") as { [id: Ulid]: Message };
   let messageRepliedTo = $derived(message.replyTo && messages[message.replyTo]);
-  let replyingToProfile = $derived(messageRepliedTo && getProfile(messageRepliedTo.author))
+  let profileRepliedTo = $derived(messageRepliedTo && getProfile(messageRepliedTo.author))
   
   let isSelected = $state(false);
   let isThreading: { value: boolean } = getContext("isThreading");
@@ -45,16 +45,16 @@
 </script>
 
 <li class="flex flex-col">
-  {#if messageRepliedTo && replyingToProfile}
+  {#if messageRepliedTo && profileRepliedTo}
     <Button.Root class="flex gap-2 text-start w-full items-center text-gray-300 px-4 py-1 bg-violet-900 rounded-t">
       <Icon icon="prime:reply" />
       <Avatar.Root class="w-4">
-        <Avatar.Image src={replyingToProfile.avatarUrl} class="rounded-full" />
+        <Avatar.Image src={profileRepliedTo.avatarUrl} class="rounded-full" />
         <Avatar.Fallback>
-          <AvatarBeam name={replyingToProfile.handle} />
+          <AvatarBeam name={profileRepliedTo.handle} />
         </Avatar.Fallback>
       </Avatar.Root>
-      <h5 class="text-white font-medium">{replyingToProfile.handle}</h5>
+      <h5 class="text-white font-medium">{profileRepliedTo.handle}</h5>
       <p class="text-ellipsis italic">
         {@html renderMarkdownSanitized(messageRepliedTo.content)}
       </p>
@@ -99,7 +99,7 @@
     <Toolbar.Root class="hidden group-hover:block absolute -top-2 right-0 bg-violet-800 p-2 rounded">
       <Toolbar.Button 
         onclick={() => setReplyTo({ id, profile, content: message.content })} 
-        class="p-2 hover:bg-white/10 rounded cursor-pointer"
+        class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
       >
         <Icon icon="fa6-solid:reply" color="white" />
       </Toolbar.Button>

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -22,6 +22,7 @@
   const removeSelectedMessage: (message: Ulid) => void = getContext(
     "removeSelectedMessage",
   );
+
   function updateSelect() {
     if (isSelected) {
       selectMessage(id);
@@ -36,6 +37,11 @@
     content: string
   }) => void;
 
+  function scrollToReply() {
+    if (!message.replyTo) { return; }
+    let element = document.getElementById(message.replyTo);
+    element?.scrollIntoView();
+  }
 
   $effect(() => {
     if (!isThreading.value) {
@@ -44,9 +50,9 @@
   });
 </script>
 
-<li class="flex flex-col">
+<li {id} class="flex flex-col">
   {#if messageRepliedTo && profileRepliedTo}
-    <Button.Root class="flex gap-2 text-start w-full items-center text-gray-300 px-4 py-1 bg-violet-900 rounded-t">
+    <Button.Root onclick={scrollToReply} class="cursor-pointer flex gap-2 text-start w-full items-center text-gray-300 px-4 py-1 bg-violet-900 rounded-t">
       <Icon icon="prime:reply" />
       <Avatar.Root class="w-4">
         <Avatar.Image src={profileRepliedTo.avatarUrl} class="rounded-full" />

--- a/src/lib/profile.svelte.ts
+++ b/src/lib/profile.svelte.ts
@@ -4,26 +4,28 @@ let cache: {
   [did: string]: {
     handle: string;
     avatarUrl: string;
-    loaded: boolean;
+    new: boolean;
   };
 } = $state({});
 
 export function getProfile(did: string): { handle: string; avatarUrl: string } {
   if (!cache[did]) {
-    cache[did] = { handle: "", avatarUrl: "", loaded: false };
+    cache[did] = { handle: "", avatarUrl: "", new: true };
   }
   const entry = cache[did];
 
-  if (!entry.loaded) {
-    if (user.agent) {
-      user.agent.getProfile({ actor: did }).then(async (resp) => {
-        if (!resp.success) return;
-        entry.handle = resp.data.handle;
-        entry.avatarUrl = resp.data.avatar || "";
-        entry.loaded = true;
-      });
+  queueMicrotask(() => {
+    if (entry.new == true) {
+      entry.new = false;
+      if (user.agent) {
+        user.agent.getProfile({ actor: did }).then(async (resp) => {
+          if (!resp.success) return;
+          entry.handle = resp.data.handle;
+          entry.avatarUrl = resp.data.avatar || "";
+        });
+      }
     }
-  }
+  });
 
   return entry;
 }

--- a/src/routes/(app)/dm/[did]/+page.svelte
+++ b/src/routes/(app)/dm/[did]/+page.svelte
@@ -2,7 +2,7 @@
   import type { Autodoc } from "$lib/autodoc/peer.ts";
   import ChatArea from "$lib/components/ChatArea.svelte";
   import { g } from "$lib/global.svelte";
-  import type { Channel, Thread, Ulid } from "$lib/schemas/types";
+  import type { Channel, Message, Thread, Ulid } from "$lib/schemas/types";
   import { page } from "$app/state";
   import { user } from "$lib/user.svelte";
   import { setContext, untrack } from "svelte";
@@ -25,6 +25,7 @@
   import toast from "svelte-french-toast";
   import _ from "underscore";
   import { unreadCount } from "$lib/utils";
+  import { renderMarkdownSanitized } from "$lib/markdown";
   import type { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
 
   let tab = $state("chat");
@@ -76,6 +77,24 @@
       selectedMessages = [];
     }
   });
+
+  // Reply Utils
+  let replyingTo = $state<{
+    id: Ulid;
+    profile: { handle: string; avatarUrl: string };
+    content: string;
+  } | null>();
+
+  setContext(
+    "setReplyTo",
+    (value: {
+      id: Ulid;
+      profile: { handle: string; avatarUrl: string };
+      content: string;
+    }) => {
+      replyingTo = value;
+    },
+  );
 
   // Mark the current DM as read.
   $effect(() => {
@@ -140,11 +159,13 @@
         author: user.agent.assertDid,
         reactions: {},
         content: messageInput,
+        ...(replyingTo && { replyTo: replyingTo.id }),
       };
       doc.timeline.push(id);
     });
 
     messageInput = "";
+    replyingTo = null;
   }
 
   function deleteThread(id: Ulid) {
@@ -307,7 +328,22 @@
 {#if channel}
   {#if tab === "chat"}
     <ChatArea {channel} />
-    <form onsubmit={sendMessage}>
+    <form onsubmit={sendMessage} class="flex flex-col">
+      {#if replyingTo}
+        <div class="flex justify-between bg-violet-700">
+          <div class="flex flex-col gap-1">
+            <h5 class="font-semibold">
+              Replying to {replyingTo.profile.handle}
+            </h5>
+            <p class="text-gray-300 text-ellipsis">
+              {@html renderMarkdownSanitized(replyingTo.content)}
+            </p>
+          </div>
+          <Button.Root type="button" onclick={() => (replyingTo = null)}>
+            <Icon icon="gg:close-o" />
+          </Button.Root>
+        </div>
+      {/if}
       <input
         type="text"
         class="w-full px-4 py-2 rounded-lg bg-violet-900 flex-none text-white"
@@ -374,6 +410,7 @@
             </Dialog.Portal>
           </Dialog.Root>
         </menu>
+
         {#each currentThread.timeline as id}
           <ChatMessage {id} message={channel.view.messages[id]} />
         {/each}

--- a/src/routes/(app)/dm/[did]/+page.svelte
+++ b/src/routes/(app)/dm/[did]/+page.svelte
@@ -330,23 +330,30 @@
     <ChatArea {channel} />
     <form onsubmit={sendMessage} class="flex flex-col">
       {#if replyingTo}
-        <div class="flex justify-between bg-violet-700">
+        <div class="flex justify-between bg-violet-800 text-white rounded-t-lg px-4 py-2">
           <div class="flex flex-col gap-1">
-            <h5 class="font-semibold">
-              Replying to {replyingTo.profile.handle}
+            <h5 class="flex gap-2 items-center">
+              Replying to 
+              <Avatar.Root class="w-4">
+                <Avatar.Image src={replyingTo.profile.avatarUrl} class="rounded-full" />
+                <Avatar.Fallback>
+                  <AvatarBeam name={replyingTo.profile.handle} />
+                </Avatar.Fallback>
+              </Avatar.Root>
+              <strong>{replyingTo.profile.handle}</strong>
             </h5>
-            <p class="text-gray-300 text-ellipsis">
+            <p class="text-gray-300 text-ellipsis italic">
               {@html renderMarkdownSanitized(replyingTo.content)}
             </p>
           </div>
-          <Button.Root type="button" onclick={() => (replyingTo = null)}>
-            <Icon icon="gg:close-o" />
+          <Button.Root type="button" onclick={() => replyingTo = null} class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150">
+            <Icon icon="zondicons:close-solid" />
           </Button.Root>
         </div>
       {/if}
       <input
         type="text"
-        class="w-full px-4 py-2 rounded-lg bg-violet-900 flex-none text-white"
+        class={`w-full px-4 py-2 flex-none text-white bg-violet-900 ${replyingTo ? "rounded-b-lg" : "rounded-lg"}`}
         placeholder="Say something..."
         bind:value={messageInput}
       />


### PR DESCRIPTION
Implements replying UX flow, where users can select a message to "reply to", which sets it as part of the input, indicated by a preview above the text box. They can deselect it or select another message. Messages that are replying to another will have a banner showing the other above it. Clicking the banner will scroll the user to that position.