### PR TITLE
fix: update tiptap editor on extension change

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -38,6 +38,7 @@
     "npm:svelte-boring-avatars@^1.2.6": "1.2.6",
     "npm:svelte-check@4": "4.1.4_svelte@5.19.3__acorn@8.14.0_typescript@5.7.3",
     "npm:svelte-french-toast@^1.2.0": "1.2.0_svelte@4.2.19",
+    "npm:svelte-render-scan@^1.0.4": "1.0.4_svelte@5.19.3__acorn@8.14.0",
     "npm:svelte-tiptap@^2.1.0": "2.1.0_@tiptap+core@2.11.5__@tiptap+pm@2.11.5___prosemirror-model@1.24.1___prosemirror-state@1.4.3___prosemirror-view@1.38.0_@tiptap+extension-bubble-menu@2.11.5__@tiptap+core@2.11.5___@tiptap+pm@2.11.5____prosemirror-model@1.24.1____prosemirror-state@1.4.3____prosemirror-view@1.38.0__@tiptap+pm@2.11.5___prosemirror-model@1.24.1___prosemirror-state@1.4.3___prosemirror-view@1.38.0_@tiptap+extension-floating-menu@2.11.5__@tiptap+core@2.11.5___@tiptap+pm@2.11.5____prosemirror-model@1.24.1____prosemirror-state@1.4.3____prosemirror-view@1.38.0__@tiptap+pm@2.11.5___prosemirror-model@1.24.1___prosemirror-state@1.4.3___prosemirror-view@1.38.0_@tiptap+pm@2.11.5__prosemirror-model@1.24.1__prosemirror-state@1.4.3__prosemirror-view@1.38.0_svelte@5.19.3__acorn@8.14.0",
     "npm:svelte@^5.19.3": "5.19.3_acorn@8.14.0",
     "npm:tailwindcss@4": "4.0.0",
@@ -2328,6 +2329,12 @@
         "svelte-writable-derived"
       ]
     },
+    "svelte-render-scan@1.0.4_svelte@5.19.3__acorn@8.14.0": {
+      "integrity": "sha512-JCZ5kqBc+67CJqBVF4Bs48UslbGKbcxTrqwicBNUwYDtz17my1gXWvJkvPRE1//q92jNNWrHPovLAlSp8dnvQA==",
+      "dependencies": [
+        "svelte@5.19.3_acorn@8.14.0"
+      ]
+    },
     "svelte-tiptap@2.1.0_@tiptap+core@2.11.5__@tiptap+pm@2.11.5___prosemirror-model@1.24.1___prosemirror-state@1.4.3___prosemirror-view@1.38.0_@tiptap+extension-bubble-menu@2.11.5__@tiptap+core@2.11.5___@tiptap+pm@2.11.5____prosemirror-model@1.24.1____prosemirror-state@1.4.3____prosemirror-view@1.38.0__@tiptap+pm@2.11.5___prosemirror-model@1.24.1___prosemirror-state@1.4.3___prosemirror-view@1.38.0_@tiptap+extension-floating-menu@2.11.5__@tiptap+core@2.11.5___@tiptap+pm@2.11.5____prosemirror-model@1.24.1____prosemirror-state@1.4.3____prosemirror-view@1.38.0__@tiptap+pm@2.11.5___prosemirror-model@1.24.1___prosemirror-state@1.4.3___prosemirror-view@1.38.0_@tiptap+pm@2.11.5__prosemirror-model@1.24.1__prosemirror-state@1.4.3__prosemirror-view@1.38.0_svelte@5.19.3__acorn@8.14.0": {
       "integrity": "sha512-CtmBM4RzJ7dibuglG6g8YsiyEiaFWAu6qFuX73STuxKFJqoBuqXQWpJqQRttrUWVp/rrrDFjd08zyC1Zzrl/Qg==",
       "dependencies": [
@@ -2677,6 +2684,7 @@
         "npm:svelte-boring-avatars@^1.2.6",
         "npm:svelte-check@4",
         "npm:svelte-french-toast@^1.2.0",
+        "npm:svelte-render-scan@^1.0.4",
         "npm:svelte-tiptap@^2.1.0",
         "npm:svelte@^5.19.3",
         "npm:tailwindcss@4",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "sanitize-html": "^2.14.0",
     "svelte": "^5.19.3",
     "svelte-check": "^4.0.0",
+    "svelte-render-scan": "^1.0.4",
     "tailwindcss": "^4.0.0",
     "tweetnacl": "^1.0.3",
     "typescript": "^5.0.0",

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -15,6 +15,7 @@
   import AvatarImage from "$lib/components/AvatarImage.svelte";
 
   import { Toaster } from "svelte-french-toast";
+  import { RenderScan } from "svelte-render-scan";
   import { AvatarPixel } from "svelte-boring-avatars";
   import { Avatar, Button, ToggleGroup } from "bits-ui";
 
@@ -109,6 +110,10 @@
 <svelte:head>
   <title>Roomy</title>
 </svelte:head>
+
+{#if dev}
+  <RenderScan />
+{/if}
 
 <!-- Container -->
 <div class="flex w-screen h-screen bg-violet-950">


### PR DESCRIPTION
Implement an `$effect` in `ChatInput` that destroys and updates the existing tiptap editor instance when extension changes. 

Closes #87 