### PR TITLE
feat: ejected threads

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -26,7 +26,7 @@
     "npm:@types/underscore@^1.13.0": "1.13.0",
     "npm:base32-decode@1": "1.0.0",
     "npm:base32-encode@2": "2.0.0",
-    "npm:bits-ui@^1.3.4": "1.3.4_svelte@5.19.3__acorn@8.14.0",
+    "npm:bits-ui@^1.3.5": "1.3.5_svelte@5.19.3__acorn@8.14.0",
     "npm:date-fns@^4.1.0": "4.1.0",
     "npm:emoji-picker-element@^1.26.1": "1.26.1",
     "npm:js-base64@^3.7.7": "3.7.7",
@@ -1172,8 +1172,8 @@
         "svelte@5.19.3_acorn@8.14.0"
       ]
     },
-    "bits-ui@1.3.4_svelte@5.19.3__acorn@8.14.0": {
-      "integrity": "sha512-hmrYbmb5D3ecRHP9GWTlkoo/9IGsPwMCmy3dAPKAfztG/NhWk49JcpuPbWi/eIggetVnv5nYrFp3N8zWscePCA==",
+    "bits-ui@1.3.5_svelte@5.19.3__acorn@8.14.0": {
+      "integrity": "sha512-pfd8MK5Hp7bOvsW25LJrWVABmBIeAOH3g0pFPJLBIKlcqsaalEdBYejQmlSwrynEDX589aW3hTAWbhmWqRjjrQ==",
       "dependencies": [
         "@floating-ui/core",
         "@floating-ui/dom",
@@ -2673,7 +2673,7 @@
         "npm:@types/underscore@^1.13.0",
         "npm:base32-decode@1",
         "npm:base32-encode@2",
-        "npm:bits-ui@^1.3.4",
+        "npm:bits-ui@^1.3.5",
         "npm:date-fns@^4.1.0",
         "npm:emoji-picker-element@^1.26.1",
         "npm:js-base64@^3.7.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@tiptap/pm": "^2.11.5",
     "@tiptap/starter-kit": "^2.11.5",
     "@tiptap/suggestion": "^2.11.5",
-    "bits-ui": "^1.3.4",
+    "bits-ui": "^1.3.5",
     "emoji-picker-element": "^1.26.1",
     "svelte-boring-avatars": "^1.2.6",
     "svelte-french-toast": "^1.2.0",

--- a/src/app.css
+++ b/src/app.css
@@ -48,7 +48,7 @@ emoji-picker {
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
-  @apply hover:scale-105 active:scale-95
+  @apply hover:scale-[101%] active:scale-95
 }
 
 /* TipTap Nodes */

--- a/src/app.css
+++ b/src/app.css
@@ -36,6 +36,21 @@ emoji-picker {
   --button-hover-background: --alpha(var(--color-white) / 10%);
 }
 
+/* Universal */
+
+.btn {
+  padding-left: 1rem; 
+  padding-right: 1rem;
+  padding-top: 0.5rem; 
+  padding-bottom: 0.5rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+  @apply hover:scale-105 active:scale-95
+}
+
 /* TipTap Nodes */
 
 .mention {

--- a/src/app.css
+++ b/src/app.css
@@ -61,6 +61,7 @@ emoji-picker {
   padding-left: 0.5rem; 
   padding-right: 0.5rem;
   border-radius: 0.25rem;
+  font-style: normal !important;
 }
 
 .thread-mention::before {

--- a/src/app.css
+++ b/src/app.css
@@ -66,10 +66,12 @@ emoji-picker {
 
 .thread-mention::before {
   content: "🧵";
+  padding-right: 0.25rem;
 }
 
 .channel-mention::before {
   content: "💬";
+  padding-right: 0.25rem;
 }
 
 /* ChatMessage */

--- a/src/lib/components/ChatArea.svelte
+++ b/src/lib/components/ChatArea.svelte
@@ -3,10 +3,9 @@
   import { onNavigate } from "$app/navigation";
   import ChatMessage from "./ChatMessage.svelte";
   import type { Autodoc } from "$lib/autodoc/peer";
-  import type { Announcement, DM, Message, Space, Ulid } from "$lib/schemas/types";
+  import type { DM, Message, Space, Ulid } from "$lib/schemas/types";
   import { Virtualizer } from "virtua/svelte";
   import { setContext } from "svelte";
-  import { decodeTime } from "ulidx";
   import { isAnnouncement } from "$lib/utils";
 
   let {
@@ -19,24 +18,10 @@
     timeline: Ulid[]
   } = $props();
 
-  let messages = $derived.by(() => {
-    const list = source.type == "dm"
-      ? source.channel.view.messages
-      : source.space.view.messages;
-
-    const orderedUlids = Object.keys(list).sort((a,b) => decodeTime(a) - decodeTime(b));
-    const newList = {} as Record<Ulid, Message | Announcement>;
-    for (const ulid of orderedUlids) {
-      newList[ulid] = list[ulid]; 
-    }
-
-    console.log({ 
-      list: Object.keys(list).map((t) => decodeTime(t)), 
-      newList: Object.keys(newList).map((t) => decodeTime(t)) 
-    });
-
-    return newList;
-  });
+  let messages = $derived(source.type == "dm"
+    ? source.channel.view.messages
+    : source.space.view.messages
+  );
 
   $inspect({ messages });
 

--- a/src/lib/components/ChatArea.svelte
+++ b/src/lib/components/ChatArea.svelte
@@ -49,8 +49,6 @@
       scrollToEnd = false;
     }
   });
-
-  $inspect({ messages });
 </script>
 
 <ScrollArea.Root type="always">

--- a/src/lib/components/ChatArea.svelte
+++ b/src/lib/components/ChatArea.svelte
@@ -3,28 +3,24 @@
   import { onNavigate } from "$app/navigation";
   import ChatMessage from "./ChatMessage.svelte";
   import type { Autodoc } from "$lib/autodoc/peer";
-  import type { Channel, Message, Space } from "$lib/schemas/types";
+  import type { DM, Message, Space, Ulid } from "$lib/schemas/types";
   import { Virtualizer } from "virtua/svelte";
   import { setContext } from "svelte";
 
   let {
     source,
+    timeline
   }: {
     source:
-      | { type: "channel"; channel: Autodoc<Channel> }
-      | { type: "space"; space: Autodoc<Space>; channelId: string };
+      | { type: "channel"; channel: Autodoc<DM> }
+      | { type: "space"; space: Autodoc<Space>; };
+    timeline: Ulid[]
   } = $props();
 
   let messages = $derived(
     source.type == "channel"
       ? source.channel.view.messages
       : source.space.view.messages,
-  );
-
-  let timeline = $derived(
-    source.type == "channel"
-      ? source.channel.view.timeline
-      : source.space.view.channels[source.channelId]?.timeline,
   );
 
   setContext("scrollToMessage", (id: string) => {

--- a/src/lib/components/ChatArea.svelte
+++ b/src/lib/components/ChatArea.svelte
@@ -79,7 +79,7 @@
         >
           {#snippet children(id, _index)}
             {@const message = messages[id]}
-            {#if message}
+            {#if message && !message.softDeleted}
               <ChatMessage 
                 {id} 
                 {message}
@@ -90,7 +90,9 @@
                 }
               />
             {:else}
-              <p class="italic text-white text-sm">This message has been deleted</p>
+              <p class="italic text-white text-sm">
+                This message has been deleted
+              </p>
             {/if}
           {/snippet}
         </Virtualizer>

--- a/src/lib/components/ChatArea.svelte
+++ b/src/lib/components/ChatArea.svelte
@@ -23,8 +23,6 @@
     : source.space.view.messages
   );
 
-  $inspect({ messages });
-
   setContext("scrollToMessage", (id: string) => {
     const idx = timeline.indexOf(id);
     if (idx !== -1 && virtualizer)

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -203,7 +203,7 @@
       {@render announcementView()}
     {:else}
       {@render replyBanner()}
-      {@render messageView(message)}
+      {@render messageView(id, message)}
     {/if}
 
     {#if Object.keys(message.reactions).length > 0}
@@ -241,7 +241,7 @@
         class="flex flex-col text-start gap-2 text-white w-full min-w-0"
       >
         <section class="flex items-center gap-2 flex-wrap w-fit">
-          {@render timestamp()}
+          {@render timestamp(id)}
         </section>
 
         <p
@@ -260,21 +260,22 @@
         }}
         class="cursor-pointer flex gap-2 text-start w-full items-center text-gray-300 px-4 py-1 bg-violet-900 rounded-t"
       >
+        <Icon icon="prime:reply" width="12px" height="12px" />
         <p
           class="text-sm italic prose-invert chat min-w-0 max-w-full overflow-hidden text-ellipsis"
         >
           {@html getAnnouncementHtml(announcement)}
         </p>
+        {@render timestamp(id)}
       </Button.Root>
       <div class="flex items-start gap-4">
-        <Icon icon="mingcute:corner-down-right-line" color="white" />
-        {@render messageView(related)}
+        {@render messageView(announcement.relatedMessages![0], related)}
       </div>
     {/if}
   </div>
 {/snippet}
 
-{#snippet messageView(msg: Message)}
+{#snippet messageView(ulid: Ulid, msg: Message)}
   <!-- doesn't change after render, so $derived is not necessary -->
   {@const authorProfile = getProfile(msg.author)}
 
@@ -306,7 +307,7 @@
         >
           <h5 class="font-bold">{authorProfile.handle}</h5>
         </a>
-        {@render timestamp()}
+        {@render timestamp(ulid)}
       </section>
 
       <p
@@ -454,8 +455,8 @@
   {/if}
 {/snippet}
 
-{#snippet timestamp()}
-  {@const decodedTime = decodeTime(id)}
+{#snippet timestamp(ulid: Ulid)}
+  {@const decodedTime = decodeTime(ulid)}
   {@const formattedDate = isToday(decodedTime)
     ? "Today"
     : format(decodedTime, "P")}

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -21,16 +21,10 @@
   type Props = {
     id: Ulid;
     message: Message | Announcement;
-    messageRepliedTo?: Message;
   };
 
-  let { id, message, messageRepliedTo }: Props = $props();
+  let { id, message }: Props = $props();
   let space: { value: Autodoc<Space> } = getContext("space");
-
-  // doesn't change after render, so $derived is not necessary
-  const authorProfile = !isAnnouncement(message) && getProfile(message.author);
-  const profileRepliedTo =
-    messageRepliedTo && getProfile(messageRepliedTo.author);
 
   // set initial set with entries, no need for $effect
   let reactionHandles = $state(
@@ -168,7 +162,7 @@
         schema.content.push({
           "type": "paragraph",
           "content": [
-            { "type": "text", "text": "This message has been moved: " },
+            { "type": "text", "text": "Moved to: " },
             { 
               "type": "channelThreadMention",
               "attrs": {
@@ -202,14 +196,13 @@
 <svelte:window onkeydown={onKeydown} onkeyup={onKeyup} />
 
 <li {id} class={`flex flex-col ${isMobile && "max-w-screen"}`}>
-  {@render replyBanner()}
-
   <div
     class="relative group w-full h-fit flex flex-col gap-4 px-2 py-2.5 hover:bg-white/5 transition-all duration-75"
   >
     {#if isAnnouncement(message)}
-      {@render announcementView(message)}
+      {@render announcementView()}
     {:else}
+      {@render replyBanner()}
       {@render messageView(message)}
     {/if}
 
@@ -231,166 +224,14 @@
       </div>
     {/if}
 
-    {#if isMobile}
-      <Drawer bind:isDrawerOpen>
-        <div class="flex gap-4 justify-center mb-4">
-          <Button.Root
-            onclick={() => {
-              toggleReaction(id, "👍");
-              isDrawerOpen = false;
-            }}
-            class="px-4 rounded-full bg-violet-800"
-          >
-            👍
-          </Button.Root>
-          <Button.Root
-            onclick={() => {
-              toggleReaction(id, "😂");
-              isDrawerOpen = false;
-            }}
-            class="px-4 rounded-full bg-violet-800"
-          >
-            😂
-          </Button.Root>
-          <Popover.Root bind:open={isEmojiDrawerPickerOpen}>
-            <Popover.Trigger class="p-4 rounded-full bg-violet-800">
-              <Icon icon="lucide:smile-plus" color="white" />
-            </Popover.Trigger>
-            <Popover.Content>
-              <emoji-picker bind:this={emojiDrawerPicker}></emoji-picker>
-            </Popover.Content>
-          </Popover.Root>
-        </div>
-
-        {#if authorProfile}
-          <div class="flex flex-col gap-2">
-            <Button.Root
-              onclick={() => {
-                setReplyTo({ id, authorProfile, content: message.content });
-                isDrawerOpen = false;
-              }}
-              class="text-white p-4 flex gap-4 items-center bg-violet-800 w-full rounded-lg"
-            >
-              <Icon icon="fa6-solid:reply" color="white" />
-              Reply
-            </Button.Root>
-            {#if mayDelete}
-              <Button.Root
-                onclick={() => deleteMessage(id)}
-                class="text-white p-4 flex gap-4 items-center bg-violet-800 w-full rounded-lg"
-              >
-                <Icon icon="tabler:trash" color="red" />
-                Delete
-              </Button.Root>
-            {/if}
-          </div>
-        {/if}
-      </Drawer>
-    {:else}
-      <Toolbar.Root
-        class={`${!isEmojiToolbarPickerOpen && "hidden"} group-hover:flex absolute -top-2 right-0 bg-violet-800 p-2 rounded items-center`}
-      >
-        <Toolbar.Button
-          onclick={() => toggleReaction(id, "👍")}
-          class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
-        >
-          👍
-        </Toolbar.Button>
-        <Toolbar.Button
-          onclick={() => toggleReaction(id, "😂")}
-          class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
-        >
-          😂
-        </Toolbar.Button>
-        <Popover.Root bind:open={isEmojiToolbarPickerOpen}>
-          <Popover.Trigger
-            class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
-          >
-            <Icon icon="lucide:smile-plus" color="white" />
-          </Popover.Trigger>
-          <Popover.Content>
-            <emoji-picker bind:this={emojiToolbarPicker}></emoji-picker>
-          </Popover.Content>
-        </Popover.Root>
-        {#if shiftDown && mayDelete}
-          <Toolbar.Button
-            onclick={() => deleteMessage(id)}
-            class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
-          >
-            <Icon icon="tabler:trash" color="red" />
-          </Toolbar.Button>
-        {/if}
-
-        {#if authorProfile}
-          <Toolbar.Button
-            onclick={() =>
-              setReplyTo({ id, authorProfile, content: message.content })}
-            class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
-          >
-            <Icon icon="fa6-solid:reply" color="white" />
-          </Toolbar.Button>
-        {/if}
-      </Toolbar.Root>
-    {/if}
-
-    {#if isThreading.value && !isAnnouncement(message)}
-      <Checkbox.Root
-        onCheckedChange={updateSelect} 
-        bind:checked={isSelected}
-        class="absolute right-4 inset-y-0"
-      >
-        {#snippet children({ checked })}
-          <div class="border bg-violet-800 size-4 rounded items-center cursor-pointer">
-            {#if checked}
-              <Icon 
-                icon="material-symbols:check-rounded" 
-                color="#5b21b6" 
-                class="bg-white size-3.5"
-              />
-            {/if}
-          </div>
-        {/snippet}
-      </Checkbox.Root>
-    {/if}
   </div>
 </li>
 
-{#snippet announcementView(message: Announcement)}
-  <div class="flex gap-4">
-    <Button.Root
-      onclick={() => {
-        if (isMobile) {
-          isDrawerOpen = true;
-        }
-      }}
-      class="flex flex-col text-start gap-2 text-white w-full min-w-0"
-    >
-      <section class="flex items-center gap-2 flex-wrap w-fit">
-        {@render timestamp()}
-      </section>
-
-      <p
-        class="text-sm italic prose-invert chat min-w-0 max-w-full overflow-hidden text-ellipsis"
-      >
-        {@html getAnnouncementHtml(message)}
-      </p>
-    </Button.Root>
-  </div>
-{/snippet}
-
-{#snippet messageView(message: Message)}
-  {#if authorProfile}
-    <div class="flex gap-4">
-      <a
-        href={`https://bsky.app/profile/${authorProfile.handle}`}
-        target="_blank"
-      >
-        <AvatarImage
-          handle={authorProfile.handle}
-          avatarUrl={authorProfile.avatarUrl}
-        />
-      </a>
-
+{#snippet announcementView()}
+  {@const announcement = message as Announcement}
+  {@render toolbar()}
+  <div class="flex flex-col gap-4">
+    {#if announcement.kind === "threadCreated"}
       <Button.Root
         onclick={() => {
           if (isMobile) {
@@ -400,34 +241,216 @@
         class="flex flex-col text-start gap-2 text-white w-full min-w-0"
       >
         <section class="flex items-center gap-2 flex-wrap w-fit">
-          <a
-            href={`https://bsky.app/profile/${authorProfile.handle}`}
-            target="_blank"
-          >
-            <h5 class="font-bold">{authorProfile.handle}</h5>
-          </a>
           {@render timestamp()}
         </section>
 
         <p
-          class="text-lg prose-invert chat min-w-0 max-w-full overflow-hidden text-ellipsis"
+          class="text-sm italic prose-invert chat min-w-0 max-w-full overflow-hidden text-ellipsis"
         >
-          {@html getContentHtml(message.content)}
+          {@html getAnnouncementHtml(announcement)}
         </p>
-        {#if message.images?.length}
-          <div class="flex flex-wrap gap-2 mt-2">
-            {#each message.images as image}
-              <img
-                src={image.source}
-                alt={image.alt || ""}
-                class="max-w-md max-h-64 rounded-lg object-cover"
-                loading="lazy"
-              />
-            {/each}
-          </div>
-        {/if}
       </Button.Root>
-    </div>
+    {:else if announcement.kind === "messageMoved"}
+      {@const related = space.value.view.messages[announcement.relatedMessages![0]] as Message} 
+      <Button.Root
+        onclick={() => {
+          if (isMobile) {
+            isDrawerOpen = true;
+          }
+        }}
+        class="cursor-pointer flex gap-2 text-start w-full items-center text-gray-300 px-4 py-1 bg-violet-900 rounded-t"
+      >
+        <p
+          class="text-sm italic prose-invert chat min-w-0 max-w-full overflow-hidden text-ellipsis"
+        >
+          {@html getAnnouncementHtml(announcement)}
+        </p>
+      </Button.Root>
+      <div class="flex items-start gap-4">
+        <Icon icon="mingcute:corner-down-right-line" color="white" />
+        {@render messageView(related)}
+      </div>
+    {/if}
+  </div>
+{/snippet}
+
+{#snippet messageView(msg: Message)}
+  <!-- doesn't change after render, so $derived is not necessary -->
+  {@const authorProfile = getProfile(msg.author)}
+
+  {@render toolbar(authorProfile)}
+
+  <div class="flex gap-4">
+    <a
+      href={`https://bsky.app/profile/${authorProfile.handle}`}
+      target="_blank"
+    >
+      <AvatarImage
+        handle={authorProfile.handle}
+        avatarUrl={authorProfile.avatarUrl}
+      />
+    </a>
+
+    <Button.Root
+      onclick={() => {
+        if (isMobile) {
+          isDrawerOpen = true;
+        }
+      }}
+      class="flex flex-col text-start gap-2 text-white w-full min-w-0"
+    >
+      <section class="flex items-center gap-2 flex-wrap w-fit">
+        <a
+          href={`https://bsky.app/profile/${authorProfile.handle}`}
+          target="_blank"
+        >
+          <h5 class="font-bold">{authorProfile.handle}</h5>
+        </a>
+        {@render timestamp()}
+      </section>
+
+      <p
+        class="text-lg prose-invert chat min-w-0 max-w-full overflow-hidden text-ellipsis"
+      >
+        {@html getContentHtml(msg.content)}
+      </p>
+      {#if msg.images?.length}
+        <div class="flex flex-wrap gap-2 mt-2">
+          {#each msg.images as image}
+            <img
+              src={image.source}
+              alt={image.alt || ""}
+              class="max-w-md max-h-64 rounded-lg object-cover"
+              loading="lazy"
+            />
+          {/each}
+        </div>
+      {/if}
+    </Button.Root>
+  </div>
+{/snippet}
+
+{#snippet toolbar(authorProfile?: { handle: string, avatarUrl: string })}
+  {#if isMobile}
+    <Drawer bind:isDrawerOpen>
+      <div class="flex gap-4 justify-center mb-4">
+        <Button.Root
+          onclick={() => {
+            toggleReaction(id, "👍");
+            isDrawerOpen = false;
+          }}
+          class="px-4 rounded-full bg-violet-800"
+        >
+          👍
+        </Button.Root>
+        <Button.Root
+          onclick={() => {
+            toggleReaction(id, "😂");
+            isDrawerOpen = false;
+          }}
+          class="px-4 rounded-full bg-violet-800"
+        >
+          😂
+        </Button.Root>
+        <Popover.Root bind:open={isEmojiDrawerPickerOpen}>
+          <Popover.Trigger class="p-4 rounded-full bg-violet-800">
+            <Icon icon="lucide:smile-plus" color="white" />
+          </Popover.Trigger>
+          <Popover.Content>
+            <emoji-picker bind:this={emojiDrawerPicker}></emoji-picker>
+          </Popover.Content>
+        </Popover.Root>
+      </div>
+
+      {#if authorProfile}
+        <div class="flex flex-col gap-2">
+          <Button.Root
+            onclick={() => {
+              setReplyTo({ id, authorProfile, content: (message as Message).content });
+              isDrawerOpen = false;
+            }}
+            class="text-white p-4 flex gap-4 items-center bg-violet-800 w-full rounded-lg"
+          >
+            <Icon icon="fa6-solid:reply" color="white" />
+            Reply
+          </Button.Root>
+          {#if mayDelete}
+            <Button.Root
+              onclick={() => deleteMessage(id)}
+              class="text-white p-4 flex gap-4 items-center bg-violet-800 w-full rounded-lg"
+            >
+              <Icon icon="tabler:trash" color="red" />
+              Delete
+            </Button.Root>
+          {/if}
+        </div>
+      {/if}
+    </Drawer>
+  {:else}
+    <Toolbar.Root
+      class={`${!isEmojiToolbarPickerOpen && "hidden"} group-hover:flex absolute -top-2 right-0 bg-violet-800 p-2 rounded items-center`}
+    >
+      <Toolbar.Button
+        onclick={() => toggleReaction(id, "👍")}
+        class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
+      >
+        👍
+      </Toolbar.Button>
+      <Toolbar.Button
+        onclick={() => toggleReaction(id, "😂")}
+        class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
+      >
+        😂
+      </Toolbar.Button>
+      <Popover.Root bind:open={isEmojiToolbarPickerOpen}>
+        <Popover.Trigger
+          class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
+        >
+          <Icon icon="lucide:smile-plus" color="white" />
+        </Popover.Trigger>
+        <Popover.Content>
+          <emoji-picker bind:this={emojiToolbarPicker}></emoji-picker>
+        </Popover.Content>
+      </Popover.Root>
+      {#if shiftDown && mayDelete}
+        <Toolbar.Button
+          onclick={() => deleteMessage(id)}
+          class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
+        >
+          <Icon icon="tabler:trash" color="red" />
+        </Toolbar.Button>
+      {/if}
+
+      {#if authorProfile}
+        <Toolbar.Button
+          onclick={() =>
+            setReplyTo({ id, authorProfile, content: (message as Message).content })}
+          class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
+        >
+          <Icon icon="fa6-solid:reply" color="white" />
+        </Toolbar.Button>
+      {/if}
+    </Toolbar.Root>
+  {/if}
+
+  {#if isThreading.value && !isAnnouncement(message)}
+    <Checkbox.Root
+      onCheckedChange={updateSelect} 
+      bind:checked={isSelected}
+      class="absolute right-4 inset-y-0"
+    >
+      {#snippet children({ checked })}
+        <div class="border bg-violet-800 size-4 rounded items-center cursor-pointer">
+          {#if checked}
+            <Icon 
+              icon="material-symbols:check-rounded" 
+              color="#5b21b6" 
+              class="bg-white size-3.5"
+            />
+          {/if}
+        </div>
+      {/snippet}
+    </Checkbox.Root>
   {/if}
 {/snippet}
 
@@ -456,6 +479,8 @@
 {/snippet}
 
 {#snippet replyBanner()}
+  {@const messageRepliedTo = !isAnnouncement(message) && message.replyTo && space.value.view.messages[message.replyTo] as Message}
+  {@const profileRepliedTo = messageRepliedTo && getProfile(messageRepliedTo.author)}
   {#if messageRepliedTo && profileRepliedTo}
     <Button.Root
       onclick={scrollToReply}

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -16,6 +16,7 @@
   import { getContentHtml } from "$lib/tiptap/editor";
   import type { Autodoc } from "$lib/autodoc/peer";
   import { page } from "$app/state";
+  import { isAnnouncement } from "$lib/utils";
 
   type Props = {
     id: Ulid;
@@ -25,10 +26,6 @@
 
   let { id, message, messageRepliedTo }: Props = $props();
   let space: { value: Autodoc<Space> } = getContext("space");
-
-  function isAnnouncement(message: Message | Announcement): message is Announcement {
-    return (message as Announcement).kind !== undefined;    
-  }
 
   // doesn't change after render, so $derived is not necessary
   const authorProfile = !isAnnouncement(message) && getProfile(message.author);

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Avatar, Button, Popover, Toolbar } from "bits-ui";
+  import { Avatar, Button, Checkbox, Popover, Toolbar } from "bits-ui";
   import type { Announcement, Message, Space, Ulid } from "$lib/schemas/types";
   import { renderMarkdownSanitized } from "$lib/markdown";
   import { AvatarBeam } from "svelte-boring-avatars";
@@ -333,39 +333,49 @@
       </Toolbar.Root>
     {/if}
 
-    {#if isThreading.value}
-      <!-- TODO: Use bits-ui Checkbox -->
-      <input
-        type="checkbox"
-        onchange={updateSelect}
+    {#if isThreading.value && !isAnnouncement(message)}
+      <Checkbox.Root
+        onCheckedChange={updateSelect} 
         bind:checked={isSelected}
         class="absolute right-4 inset-y-0"
-      />
+      >
+        {#snippet children({ checked })}
+          <div class="border bg-violet-800 size-4 rounded items-center cursor-pointer">
+            {#if checked}
+              <Icon 
+                icon="material-symbols:check-rounded" 
+                color="#5b21b6" 
+                class="bg-white size-3.5"
+              />
+            {/if}
+          </div>
+        {/snippet}
+      </Checkbox.Root>
     {/if}
   </div>
 </li>
 
 {#snippet announcementView(message: Announcement)}
   <div class="flex gap-4">
-      <Button.Root
-        onclick={() => {
-          if (isMobile) {
-            isDrawerOpen = true;
-          }
-        }}
-        class="flex flex-col text-start gap-2 text-white w-full min-w-0"
-      >
-        <section class="flex items-center gap-2 flex-wrap w-fit">
-          {@render timestamp()}
-        </section>
+    <Button.Root
+      onclick={() => {
+        if (isMobile) {
+          isDrawerOpen = true;
+        }
+      }}
+      class="flex flex-col text-start gap-2 text-white w-full min-w-0"
+    >
+      <section class="flex items-center gap-2 flex-wrap w-fit">
+        {@render timestamp()}
+      </section>
 
-        <p
-          class="text-lg prose-invert chat min-w-0 max-w-full overflow-hidden text-ellipsis"
-        >
-          {@html getAnnouncementHtml(message)}
-        </p>
-      </Button.Root>
-    </div>
+      <p
+        class="text-sm italic prose-invert chat min-w-0 max-w-full overflow-hidden text-ellipsis"
+      >
+        {@html getAnnouncementHtml(message)}
+      </p>
+    </Button.Root>
+  </div>
 {/snippet}
 
 {#snippet messageView(message: Message)}

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import Icon from "@iconify/svelte";
-  import { fade } from "svelte/transition";
   import { Dialog, Separator } from "bits-ui";
   import type { Snippet } from "svelte";
 

--- a/src/lib/schemas/types.ts
+++ b/src/lib/schemas/types.ts
@@ -36,20 +36,31 @@ export type Did = string;
 export type Message = {
   author: Did;
   content: string;
-  replyTo?: Ulid;
   reactions: { [reaction: string]: Did[] };
+  replyTo?: Ulid;
   images?: {
     source: string;
     alt?: string;
   }[];
+  softDeleted?: boolean;
 };
+
+export type Announcement = {
+  kind: "messageMoved" | "messageDeleted" | "threadCreated";
+  reactions: { [reaction: string]: Did[] };
+  relatedMessages?: Ulid[];
+  relatedThreads?: Ulid[];
+  softDeleted?: boolean;
+}
 
 export type Thread = {
   title: string;
   timeline: Ulid[];
+  softDeleted?: boolean;
 };
 
 // Used in DMs
+// TODO: Delete since DMs are not in priority
 export type DM = {
   name: string;
   description: string;
@@ -64,7 +75,9 @@ export type Channel = {
   avatar?: string;
   threads: Ulid[];
   timeline: Ulid[];
+  softDeleted?: boolean;
 };
+
 export type SpaceCategory = {
   name: string;
   channels: Ulid[];
@@ -75,7 +88,7 @@ export type Space = {
   admins: Ulid[];
   moderators: Ulid[];
   threads: { [ulid: Ulid]: Thread };
-  messages: { [ulid: Ulid]: Message };
+  messages: { [ulid: Ulid]: Message | Announcement };
   channels: { [ulid: Ulid]: Channel };
   categories: { [ulid: Ulid]: SpaceCategory };
   sidebarItems: SidebarItem[];

--- a/src/lib/schemas/types.ts
+++ b/src/lib/schemas/types.ts
@@ -56,6 +56,7 @@ export type Announcement = {
 export type Thread = {
   title: string;
   timeline: Ulid[];
+  relatedChannel: Ulid;
   softDeleted?: boolean;
 };
 
@@ -88,8 +89,8 @@ export type Space = {
   admins: Ulid[];
   moderators: Ulid[];
   threads: { [ulid: Ulid]: Thread };
-  messages: { [ulid: Ulid]: Message | Announcement };
   channels: { [ulid: Ulid]: Channel };
+  messages: { [ulid: Ulid]: Message | Announcement };
   categories: { [ulid: Ulid]: SpaceCategory };
   sidebarItems: SidebarItem[];
   name: string;

--- a/src/lib/schemas/types.ts
+++ b/src/lib/schemas/types.ts
@@ -49,7 +49,8 @@ export type Thread = {
   timeline: Ulid[];
 };
 
-export type Channel = {
+// Used in DMs
+export type DM = {
   name: string;
   description: string;
   messages: { [ulid: Ulid]: Message };
@@ -57,7 +58,7 @@ export type Channel = {
   timeline: Ulid[];
 };
 
-export type SpaceChannel = {
+export type Channel = {
   name: string;
   description?: string;
   avatar?: string;
@@ -75,7 +76,7 @@ export type Space = {
   moderators: Ulid[];
   threads: { [ulid: Ulid]: Thread };
   messages: { [ulid: Ulid]: Message };
-  channels: { [ulid: Ulid]: SpaceChannel };
+  channels: { [ulid: Ulid]: Channel };
   categories: { [ulid: Ulid]: SpaceCategory };
   sidebarItems: SidebarItem[];
   name: string;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,7 @@ import type { DidDocument } from "@atproto/oauth-client-browser";
 import type { Doc } from "@automerge/automerge";
 import { next as Automerge } from "@automerge/automerge";
 import { decodeBase32 } from "./base32";
+import type { Announcement, Message } from "./schemas/types";
 
 /** Cleans a handle string by removing any characters not valid for a domain. */
 export function cleanHandle(handle: string): string {
@@ -54,3 +55,8 @@ export function unreadCount<Channel>(
   }
   return count;
 }
+
+export function isAnnouncement(message: Message | Announcement): message is Announcement {
+  return (message as Announcement).kind !== undefined;    
+}
+

--- a/src/routes/(app)/space/[space]/+layout.svelte
+++ b/src/routes/(app)/space/[space]/+layout.svelte
@@ -230,7 +230,7 @@
                 {/each}
               </select>
               <Button.Root
-                class={`px-4 py-2 bg-white text-black rounded-lg  active:scale-95 transition-all duration-150 flex items-center justify-center gap-2`}
+                class="px-4 py-2 bg-white text-black rounded-lg  active:scale-95 transition-all duration-150 flex items-center justify-center gap-2"
               >
                 <Icon icon="basil:add-outline" font-size="1.8em" />
                 Create Channel
@@ -250,7 +250,7 @@
     > 
       <Accordion.Item value="channels">
         <Accordion.Header>
-          <Accordion.Trigger class="cursor-pointer uppercase text-xs font-medium text-gray-300">
+          <Accordion.Trigger class="cursor-pointer mb-2 uppercase text-xs font-medium text-gray-300">
             Channels
           </Accordion.Trigger>
         </Accordion.Header>
@@ -264,8 +264,9 @@
       </Accordion.Item>
       <Accordion.Item value="threads">
         <Accordion.Header>
-          <Accordion.Trigger class="cursor-pointer uppercase text-xs font-medium text-gray-300">
-            Threads
+          <Accordion.Trigger class="cursor-pointer flex w-full items-center justify-between mb-2 uppercase text-xs font-medium text-gray-300">
+            <h3>Threads</h3>
+            <Icon icon="basil:caret-up-solid" class="size-6" /> 
           </Accordion.Trigger>
         </Accordion.Header>
         <Accordion.Content>

--- a/src/routes/(app)/space/[space]/+layout.svelte
+++ b/src/routes/(app)/space/[space]/+layout.svelte
@@ -108,6 +108,15 @@
   }
 
   let currentItemId = $state("");
+  $effect(() => {
+    if (page.params.channel) {
+      currentItemId = page.params.channel;
+    }
+    else {
+      currentItemId = page.params.thread;
+    }
+  });
+  
   let showNewChannelDialog = $state(false);
   let newChannelName = $state("");
   let newChannelCategory = $state(undefined) as undefined | string;

--- a/src/routes/(app)/space/[space]/+layout.svelte
+++ b/src/routes/(app)/space/[space]/+layout.svelte
@@ -161,7 +161,7 @@
         {space.view.name}
       </h1>
 
-      {#if isAdmin.isAdmin}
+      {#if isAdmin}
         <menu class="flex gap-2">
           <Dialog
             title="Create Category"
@@ -318,7 +318,7 @@
 
           <span class="flex-grow"></span>
 
-          {#if isAdmin.isAdmin}
+          {#if isAdmin}
             <Dialog
               title="Channel Settings"
               bind:isDialogOpen={showCategoryDialog}

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -139,8 +139,7 @@
         doc.channels[page.params.channel].timeline.splice(index, 1);
 
         // create an Announcement about the move for each message
-        const timestamp = decodeTime(id);
-        const announcementId = ulid(timestamp);
+        const announcementId = ulid();
         const announcement: Announcement = {
           kind: "messageMoved",
           relatedMessages: [id],

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -158,6 +158,7 @@
       doc.threads[threadId] = {
         title: threadTitleInput,
         timeline: threadTimeline,
+        relatedChannel: page.params.channel
       };
       
       // create an Announcement about the new Thread in current channel

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -14,17 +14,14 @@
   import Icon from "@iconify/svelte";
   import Dialog from "$lib/components/Dialog.svelte";
   import ChatArea from "$lib/components/ChatArea.svelte";
-  import ThreadRow from "$lib/components/ThreadRow.svelte";
   import ChatInput from "$lib/components/ChatInput.svelte";
-  import ChatMessage from "$lib/components/ChatMessage.svelte";
   import AvatarImage from "$lib/components/AvatarImage.svelte";
-  import { Button, Popover, ScrollArea, Tabs, Toggle } from "bits-ui";
+  import { Button, Popover, Toggle } from "bits-ui";
 
   import type {
     Did,
     Space,
     Channel,
-    Thread,
     Ulid,
   } from "$lib/schemas/types";
   import type { Autodoc } from "$lib/autodoc/peer";
@@ -32,7 +29,6 @@
 
   let isMobile = $derived((outerWidth.current ?? 0) < 640);
 
-  let tab = $state("chat");
   let space: Autodoc<Space> | undefined = $derived(g.spaces[page.params.space]);
   let channel = $derived(space.view.channels[page.params.channel]) as
     | Channel
@@ -87,21 +83,7 @@
   $inspect({ users: users(), contextItems });
 
   let messageInput = $state({});
-  let currentThread = $derived.by(() => {
-    if (page.url.searchParams.has("thread")) {
-      return space.view.threads[page.url.searchParams.get("thread")!] as Thread;
-    } else {
-      return null;
-    }
-  });
-
   let imageFiles: FileList | null = $state(null);
-
-  $effect(() => {
-    if (currentThread) {
-      tab = "threads";
-    }
-  });
 
   // thread maker
   let isThreading = $state({ value: false });
@@ -250,18 +232,6 @@
     imageFiles = null;
   }
 
-  function deleteThread(id: Ulid) {
-    if (!space) return;
-
-    space.change((doc) => {
-      delete doc.threads[id];
-    });
-
-    toast.success("Thread deleted", { position: "bottom-end" });
-    goto(page.url.pathname);
-  }
-
-
   //
   // Settings Dialog
   //
@@ -365,54 +335,11 @@
       <AvatarImage avatarUrl={channel?.avatar} handle={channel?.name ?? ""} />
     {/if}
 
-    <span class="flex gap-2 items-center">
-      {#if !isMobile || (isMobile && !currentThread)}
-        <h4
-          class={`${isMobile && "line-clamp-1 overflow-hidden text-ellipsis"} text-white text-lg font-bold`}
-        >
-          {channel?.name}
-        </h4>
-      {/if}
-
-      {#if currentThread}
-        {#if !isMobile}
-          <Icon icon="mingcute:right-line" color="white" />
-        {/if}
-        <Icon icon="lucide-lab:reel-thread" color="white" />
-        <h5 class="text-white text-lg font-bold line-clamp-1 text-ellipsis">
-          {currentThread.title}
-        </h5>
-      {/if}
-    </span>
+    <h4 class={`${isMobile && "line-clamp-1 overflow-hidden text-ellipsis"} text-white text-lg font-bold`}>
+      {channel?.name}
+    </h4>
   </div>
 
-  <Tabs.Root bind:value={tab}>
-    <Tabs.List class="grid grid-cols-2 gap-4 border text-white p-1 rounded">
-      <Tabs.Trigger
-        value="chat"
-        onclick={() => goto(page.url.pathname)}
-        class="flex gap-2 w-full justify-center transition-all duration-150 items-center px-4 py-1 data-[state=active]:bg-violet-800 rounded"
-      >
-        <Icon icon="tabler:message" color="white" class="text-2xl" />
-        {#if !isMobile}
-          <p>Chat</p>
-        {/if}
-      </Tabs.Trigger>
-      <Tabs.Trigger
-        value="threads"
-        class="flex gap-2 w-full justify-center transition-all duration-150 items-center px-4 py-1 data-[state=active]:bg-violet-800 rounded"
-      >
-        <Icon
-          icon="material-symbols:thread-unread-rounded"
-          color="white"
-          class="text-2xl"
-        />
-        {#if !isMobile}
-          <p>Threads</p>
-        {/if}
-      </Tabs.Trigger>
-    </Tabs.List>
-  </Tabs.Root>
 
   {#if !isMobile}
     <div class="flex">
@@ -421,179 +348,101 @@
   {/if}
 </header>
 
-{#if tab === "chat"}
-  {@render chatTab()}
-{:else if tab === "threads"}
-  {@render threadsTab()}
-{/if}
-
-{#snippet chatTab()}
-  {#if space}
-    <ChatArea
-      source={{ type: "space", space, channelId: page.params.channel }}
-    />
-    <div class="flex float-end">
-      {#if !isMobile || !isThreading.value}
-        <section class="grow flex flex-col">
-          {#if replyingTo}
-            <div
-              class="flex justify-between bg-violet-800 text-white rounded-t-lg px-4 py-2"
+{#if space}
+  <ChatArea
+    source={{ type: "space", space, channelId: page.params.channel }}
+  />
+  <div class="flex float-end">
+    {#if !isMobile || !isThreading.value}
+      <section class="grow flex flex-col">
+        {#if replyingTo}
+          <div
+            class="flex justify-between bg-violet-800 text-white rounded-t-lg px-4 py-2"
+          >
+            <div class="flex flex-col gap-1">
+              <h5 class="flex gap-2 items-center">
+                Replying to
+                <AvatarImage
+                  handle={replyingTo.authorProfile.handle}
+                  avatarUrl={replyingTo.authorProfile.avatarUrl}
+                  className="!w-4"
+                />
+                <strong>{replyingTo.authorProfile.handle}</strong>
+              </h5>
+              <p class="text-gray-300 text-ellipsis italic">
+                {@html getContentHtml(replyingTo.content)}
+              </p>
+            </div>
+            <Button.Root
+              type="button"
+              onclick={() => (replyingTo = null)}
+              class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150"
             >
-              <div class="flex flex-col gap-1">
-                <h5 class="flex gap-2 items-center">
-                  Replying to
-                  <AvatarImage
-                    handle={replyingTo.authorProfile.handle}
-                    avatarUrl={replyingTo.authorProfile.avatarUrl}
-                    className="!w-4"
-                  />
-                  <strong>{replyingTo.authorProfile.handle}</strong>
-                </h5>
-                <p class="text-gray-300 text-ellipsis italic">
-                  {@html getContentHtml(replyingTo.content)}
-                </p>
-              </div>
-              <Button.Root
-                type="button"
-                onclick={() => (replyingTo = null)}
-                class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150"
-              >
-                <Icon icon="zondicons:close-solid" />
-              </Button.Root>
-            </div>
-          {/if}
-          <div class="relative">
-
-            <!-- TODO: get all users that has joined the server -->
-            <ChatInput 
-              bind:content={messageInput} 
-              users={users()}
-              context={contextItems}
-              onEnter={sendMessage}
-            />
-
-            <!--
-            {#if mayUploadImages}
-              <label
-                class="cursor-pointer text-white hover:text-gray-300 absolute right-3 top-1/2 -translate-y-1/2"
-              >
-                <input
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  class="hidden"
-                  onchange={handleImageSelect}
-                />
-                <Icon
-                  icon="material-symbols:add-photo-alternate"
-                  class="text-2xl"
-                />
-              </label>
-            {/if}
-            -->
+              <Icon icon="zondicons:close-solid" />
+            </Button.Root>
           </div>
+        {/if}
+        <div class="relative">
 
-          <!-- Image preview 
-          {#if imageFiles?.length}
-            <div class="flex gap-2 flex-wrap">
-              {#each Array.from(imageFiles) as file}
-                <div class="relative mt-5">
-                  <img
-                    src={URL.createObjectURL(file)}
-                    alt={file.name}
-                    class="w-20 h-20 object-cover rounded"
-                  />
-                  <button
-                    type="button"
-                    class="absolute -top-2 -right-2 bg-red-500 rounded-full p-1"
-                    onclick={() => (imageFiles = null)}
-                  >
-                    <Icon icon="zondicons:close-solid" color="white" />
-                  </button>
-                </div>
-              {/each}
-            </div>
+          <!-- TODO: get all users that has joined the server -->
+          <ChatInput 
+            bind:content={messageInput} 
+            users={users()}
+            context={contextItems}
+            onEnter={sendMessage}
+          />
+
+          <!--
+          {#if mayUploadImages}
+            <label
+              class="cursor-pointer text-white hover:text-gray-300 absolute right-3 top-1/2 -translate-y-1/2"
+            >
+              <input
+                type="file"
+                accept="image/*"
+                multiple
+                class="hidden"
+                onchange={handleImageSelect}
+              />
+              <Icon
+                icon="material-symbols:add-photo-alternate"
+                class="text-2xl"
+              />
+            </label>
           {/if}
           -->
-        </section>
-      {/if}
+        </div>
 
-      {#if isMobile}
-        {@render toolbar({ growButton: true })}
-      {/if}
-    </div>
-  {/if}
-{/snippet}
-
-{#snippet threadsTab()}
-  {#if space}
-    {#if currentThread}
-      <section class="flex flex-col gap-4 items-start h-full">
-        <menu class="px-4 py-2 flex w-full justify-between">
-          <Button.Root
-            onclick={() => goto(page.url.pathname)}
-            class="flex gap-2 items-center text-white cursor-pointer hover:scale-105 transitiona-all duration-150"
-          >
-            <Icon icon="uil:left" />
-            Back
-          </Button.Root>
-          <Dialog title="Delete Thread" bind:isDialogOpen={showSettingsDialog}>
-            {#snippet dialogTrigger()}
-              <Icon icon="tabler:trash" color="red" class="text-2xl" />
-            {/snippet}
-            <div class="flex flex-col items-center gap-4">
-              <p>The thread will be unrecoverable once deleted.</p>
-              <Button.Root
-                onclick={() =>
-                  deleteThread(page.url.searchParams.get("thread")!)}
-                class="flex items-center gap-3 px-4 py-2 max-w-[20em] bg-red-600 text-white rounded-lg hover:scale-[102%] active:scale-95 transition-all duration-150"
-              >
-                Confirm Delete
-              </Button.Root>
-            </div>
-          </Dialog>
-        </menu>
-
-        <ScrollArea.Root>
-          <ScrollArea.Viewport class="max-w-screen h-full max-h-[90%]">
-            <ol class="flex flex-col gap-4">
-              {#each currentThread.timeline as id}
-                {@const message = space.view.messages[id]}
-                <ChatMessage
-                  {id}
-                  {message}
-                  messageRepliedTo={message.replyTo
-                    ? space.view.messages[message.replyTo]
-                    : undefined}
+        <!-- Image preview 
+        {#if imageFiles?.length}
+          <div class="flex gap-2 flex-wrap">
+            {#each Array.from(imageFiles) as file}
+              <div class="relative mt-5">
+                <img
+                  src={URL.createObjectURL(file)}
+                  alt={file.name}
+                  class="w-20 h-20 object-cover rounded"
                 />
-              {/each}
-            </ol>
-          </ScrollArea.Viewport>
-          <ScrollArea.Scrollbar
-            orientation="vertical"
-            class="flex h-full w-2.5 touch-none select-none rounded-full border-l border-l-transparent p-px transition-all hover:w-3 hover:bg-dark-10"
-          >
-            <ScrollArea.Thumb
-              class="relative flex-1 rounded-full bg-muted-foreground opacity-40 transition-opacity hover:opacity-100"
-            />
-          </ScrollArea.Scrollbar>
-          <ScrollArea.Corner />
-        </ScrollArea.Root>
+                <button
+                  type="button"
+                  class="absolute -top-2 -right-2 bg-red-500 rounded-full p-1"
+                  onclick={() => (imageFiles = null)}
+                >
+                  <Icon icon="zondicons:close-solid" color="white" />
+                </button>
+              </div>
+            {/each}
+          </div>
+        {/if}
+        -->
       </section>
-    {:else}
-      <ul class="overflow-y-auto px-2 gap-3 flex flex-col">
-        {#each Object.entries(space.view.threads) as [id, thread] (id)}
-          <ThreadRow
-            {id}
-            {thread}
-            onclick={() => goto(`?thread=${id}`)}
-            onclickDelete={() => deleteThread(id)}
-          />
-        {/each}
-      </ul>
     {/if}
-  {/if}
-{/snippet}
+
+    {#if isMobile}
+      {@render toolbar({ growButton: true })}
+    {/if}
+  </div>
+{/if}
 
 {#snippet toolbar({ growButton = false }: { growButton: boolean })}
   {#if isThreading.value}
@@ -633,15 +482,15 @@
       </Popover.Root>
     </div>
   {/if}
+
   <menu class="relative flex items-center gap-3 px-2 w-fit self-end">
     <Toggle.Root
       bind:pressed={isThreading.value}
-      disabled={tab !== "chat"}
       class={`p-2 ${isThreading.value && "bg-white/10"} cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150 rounded`}
     >
       <Icon
         icon="tabler:needle-thread"
-        color={tab !== "chat" ? "gray" : "white"}
+        color="white"
         class="text-2xl"
       />
     </Toggle.Root>

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -39,6 +39,7 @@
 
   // thread maker
   let isThreading = $state({ value: false });
+  $inspect({ isThreading })
   let threadTitleInput = $state("");
   let selectedMessages: Ulid[] = $state([]);
   setContext("isThreading", isThreading);
@@ -401,8 +402,8 @@
 
 {#snippet toolbar()}
   <menu class="relative flex items-center gap-3 px-2 w-fit self-end">
-    <Popover.Root>
-      <Popover.Trigger onclick={() => isThreading.value = !isThreading.value}>
+    <Popover.Root bind:open={isThreading.value}> 
+      <Popover.Trigger>
         <Icon
           icon="tabler:needle-thread"
           color="white"
@@ -414,11 +415,16 @@
           side="left" 
           sideOffset={8} 
           interactOutsideBehavior="ignore" 
-          class="text-white bg-violet-900 rounded p-4"
+          class="my-4 text-white bg-violet-900 rounded py-4 px-5"
         >
           <form onsubmit={createThread} class="flex flex-col gap-4">
-            <input type="text" bind:value={threadTitleInput} class="bg-violet-800" placeholder="Thread Title" />
-            <button type="submit" class="bg-violet-800 w-full rounded py-2">Create Thread</button>
+            <input type="text" bind:value={threadTitleInput} class="bg-violet-800 px-2 py-1" placeholder="Thread Title" />
+            <button 
+              type="submit" 
+              class="btn text-violet-900 bg-white"
+            >
+              Create Thread
+            </button>
           </form>
         </Popover.Content>
       </Popover.Portal>

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -35,8 +35,6 @@
   let users: { value: Item[] } = getContext("users");
   let contextItems: { value: Item[] } = getContext("contextItems");
 
-  $inspect({ space, users: users.value, contextItems: contextItems.value });
-
   let messageInput = $state({});
   let imageFiles: FileList | null = $state(null);
 

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -307,7 +307,8 @@
 
 {#if space}
   <ChatArea
-    source={{ type: "space", space: space, channelId: page.params.channel }}
+    source={{ type: "space", space: space }}
+    timeline={channel?.timeline ?? []}
   />
   <div class="flex float-end">
     {#if !isMobile || !isThreading.value}

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -5,7 +5,6 @@
   import { getContext, setContext } from "svelte";
   import { goto } from "$app/navigation";
   import toast from "svelte-french-toast";
-  import { fly } from "svelte/transition";
   import { user } from "$lib/user.svelte";
   import { getContentHtml, type Item } from "$lib/tiptap/editor";
   import { outerWidth } from "svelte/reactivity/window";
@@ -15,7 +14,7 @@
   import ChatArea from "$lib/components/ChatArea.svelte";
   import ChatInput from "$lib/components/ChatInput.svelte";
   import AvatarImage from "$lib/components/AvatarImage.svelte";
-  import { Button, Popover, Toggle } from "bits-ui";
+  import { Button, Popover } from "bits-ui";
 
   import type {
     Did,
@@ -298,7 +297,7 @@
 
   {#if !isMobile}
     <div class="flex">
-      {@render toolbar({ growButton: false })}
+      {@render toolbar()}
     </div>
   {/if}
 </header>
@@ -395,61 +394,35 @@
     {/if}
 
     {#if isMobile}
-      {@render toolbar({ growButton: true })}
+      {@render toolbar()}
     {/if}
   </div>
 {/if}
 
-{#snippet toolbar({ growButton = false }: { growButton: boolean })}
-  {#if isThreading.value}
-    <div in:fly class={`${growButton && "grow w-full pr-2"}`}>
-      <Popover.Root>
-        <Popover.Trigger
-          class={`cursor-pointer ${growButton ? "w-full" : "w-fit"} px-4 py-2 rounded bg-violet-800 text-white`}
+{#snippet toolbar()}
+  <menu class="relative flex items-center gap-3 px-2 w-fit self-end">
+    <Popover.Root>
+      <Popover.Trigger onclick={() => isThreading.value = !isThreading.value}>
+        <Icon
+          icon="tabler:needle-thread"
+          color="white"
+          class="text-2xl"
+        />
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content 
+          side="left" 
+          sideOffset={8} 
+          interactOutsideBehavior="ignore" 
+          class="text-white bg-violet-900 rounded p-4"
         >
-          Create Thread
-        </Popover.Trigger>
-
-        <Popover.Content
-          sideOffset={8}
-          forceMount
-          class="bg-violet-800 p-4 rounded"
-        >
-          <form onsubmit={createThread} class="text-white flex flex-col gap-4">
-            <label class="flex flex-col gap-1">
-              Thread Title
-              <input
-                bind:value={threadTitleInput}
-                type="text"
-                placeholder="Notes"
-                class="border px-4 py-2 rounded"
-              />
-            </label>
-            <Popover.Close>
-              <button
-                type="submit"
-                class="text-black px-4 py-2 bg-white rounded w-full text-center"
-              >
-                Confirm
-              </button>
-            </Popover.Close>
+          <form onsubmit={createThread} class="flex flex-col gap-4">
+            <input type="text" bind:value={threadTitleInput} class="bg-violet-800" placeholder="Thread Title" />
+            <button type="submit" class="bg-violet-800 w-full rounded py-2">Create Thread</button>
           </form>
         </Popover.Content>
-      </Popover.Root>
-    </div>
-  {/if}
-
-  <menu class="relative flex items-center gap-3 px-2 w-fit self-end">
-    <Toggle.Root
-      bind:pressed={isThreading.value}
-      class={`p-2 ${isThreading.value && "bg-white/10"} cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150 rounded`}
-    >
-      <Icon
-        icon="tabler:needle-thread"
-        color="white"
-        class="text-2xl"
-      />
-    </Toggle.Root>
+      </Popover.Portal>
+    </Popover.Root>
     <Button.Root
       title="Copy invite link"
       class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150"

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -27,14 +27,15 @@
 
   let isMobile = $derived((outerWidth.current ?? 0) < 640);
 
-  let { space }: { space: Autodoc<Space> | undefined } = getContext("space") 
+  let spaceContext = getContext("space") as { get value(): Autodoc<Space> | undefined };
+  let space = $derived(spaceContext.value);
   let channel = $derived(space?.view.channels[page.params.channel]) as
     | Channel
     | undefined;
-  let { users }: { users: Item[] } = getContext("users");
-  let { contextItems }: { contextItems: Item[] } = getContext("contextItems");
+  let users: { value: Item[] } = getContext("users");
+  let contextItems: { value: Item[] } = getContext("contextItems");
 
-  $inspect({ space, channel, users, contextItems });
+  $inspect({ space, users: users.value, contextItems: contextItems.value });
 
   let messageInput = $state({});
   let imageFiles: FileList | null = $state(null);
@@ -191,7 +192,7 @@
   // Settings Dialog
   //
 
-  let { isAdmin }: { isAdmin: boolean } = getContext("isAdmin");
+  let { value: isAdmin }: { value: boolean } = getContext("isAdmin");
 
   let mayUploadImages = $derived.by(() => {
     if (isAdmin) return true;
@@ -343,8 +344,8 @@
           <!-- TODO: get all users that has joined the server -->
           <ChatInput 
             bind:content={messageInput} 
-            {users}
-            context={contextItems}
+            users={users.value}
+            context={contextItems.value}
             onEnter={sendMessage}
           />
 

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -23,7 +23,7 @@
   import type {
     Did,
     Space,
-    SpaceChannel,
+    Channel,
     Thread,
     Ulid,
   } from "$lib/schemas/types";
@@ -35,7 +35,7 @@
   let tab = $state("chat");
   let space: Autodoc<Space> | undefined = $derived(g.spaces[page.params.space]);
   let channel = $derived(space.view.channels[page.params.channel]) as
-    | SpaceChannel
+    | Channel
     | undefined;
   
   // TODO: track users via the space data

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -22,7 +22,6 @@
     Channel,
     Ulid,
     Announcement,
-    Message,
   } from "$lib/schemas/types";
   import type { Autodoc } from "$lib/autodoc/peer";
 
@@ -126,6 +125,12 @@
     space.change((doc) => {
       const threadId = ulid();
       const threadTimeline: string[] = [];
+
+      // messages can be selected in any order
+      // sort them on create based on their position from the channel
+      selectedMessages.sort((a,b) => {
+        return channel.timeline.indexOf(a) - channel.timeline.indexOf(b)
+      });
 
       for (const id of selectedMessages) {
         // move selected message ID from channel to thread timeline

--- a/src/routes/(app)/space/[space]/[channel]/+page.svelte
+++ b/src/routes/(app)/space/[space]/[channel]/+page.svelte
@@ -125,10 +125,11 @@
 
     space.change((doc) => {
       const threadId = ulid();
-      const timeline: string[] = [];
+      const threadTimeline: string[] = [];
+
       for (const id of selectedMessages) {
         // move selected message ID from channel to thread timeline
-        timeline.push(id);
+        threadTimeline.push(id);
         const index = channel?.timeline.indexOf(id);
         doc.channels[page.params.channel].timeline.splice(index, 1);
 
@@ -143,13 +144,15 @@
         };
 
         doc.messages[announcementId] = announcement; 
-        doc.channels[page.params.channel].timeline.push(announcementId);
+
+        // push announcement at moved message's index
+        doc.channels[page.params.channel].timeline.splice(index, 0, announcementId);
       }
 
       // create thread
       doc.threads[threadId] = {
         title: threadTitleInput,
-        timeline,
+        timeline: threadTimeline,
       };
       
       // create an Announcement about the new Thread in current channel
@@ -162,9 +165,6 @@
 
       doc.messages[announcementId] = announcement; 
       doc.channels[page.params.channel].timeline.push(announcementId);
-
-
-      // TODO: reorder messages
     });
 
     threadTitleInput = "";

--- a/src/routes/(app)/space/[space]/thread/[thread]/+page.svelte
+++ b/src/routes/(app)/space/[space]/thread/[thread]/+page.svelte
@@ -156,6 +156,7 @@
       doc.threads[threadId] = {
         title: threadTitleInput,
         timeline: threadTimeline,
+        relatedChannel: thread.relatedChannel
       };
       
       // create an Announcement about the new Thread in current channel
@@ -268,9 +269,15 @@
       <AvatarImage handle={thread?.title ?? ""} />
     {/if}
 
-    <h4 class={`${isMobile && "line-clamp-1 overflow-hidden text-ellipsis"} text-white text-lg font-bold`}>
-      {thread?.title}
-    </h4>
+    {#if space && thread}
+      <h4 class={`${isMobile && "line-clamp-1 overflow-hidden text-ellipsis"} text-white text-lg font-bold`}>
+        {thread.title}
+      </h4>
+      <p class="text-gray-400 text-xs">{">"}</p>
+      <a href={`/space/${page.params.space}/${thread.relatedChannel}`} class="text-xs mention channel-mention">
+        {space.view.channels[thread.relatedChannel].name}
+      </a>
+    {/if}
   </div>
 
 

--- a/src/routes/(app)/space/[space]/thread/[thread]/+page.svelte
+++ b/src/routes/(app)/space/[space]/thread/[thread]/+page.svelte
@@ -137,8 +137,7 @@
         doc.threads[page.params.thread].timeline.splice(index, 1);
 
         // create an Announcement about the move for each message
-        const timestamp = decodeTime(id);
-        const announcementId = ulid(timestamp);
+        const announcementId = ulid();
         const announcement: Announcement = {
           kind: "messageMoved",
           relatedMessages: [id],

--- a/src/routes/(app)/space/[space]/thread/[ulid]/+page.svelte
+++ b/src/routes/(app)/space/[space]/thread/[ulid]/+page.svelte
@@ -257,8 +257,8 @@
 
 {#snippet toolbar()}
   <menu class="relative flex items-center gap-3 px-2 w-fit self-end">
-    <Popover.Root>
-      <Popover.Trigger onclick={() => isThreading.value = !isThreading.value}>
+    <Popover.Root bind:open={isThreading.value}> 
+      <Popover.Trigger>
         <Icon
           icon="tabler:needle-thread"
           color="white"
@@ -270,11 +270,16 @@
           side="left" 
           sideOffset={8} 
           interactOutsideBehavior="ignore" 
-          class="text-white bg-violet-900 rounded p-4"
+          class="my-4 text-white bg-violet-900 rounded py-4 px-5"
         >
           <form onsubmit={createThread} class="flex flex-col gap-4">
-            <input type="text" bind:value={threadTitleInput} class="bg-violet-800" placeholder="Thread Title" />
-            <button type="submit" class="bg-violet-800 w-full rounded py-2">Create Thread</button>
+            <input type="text" bind:value={threadTitleInput} class="bg-violet-800 px-2 py-1" placeholder="Thread Title" />
+            <button 
+              type="submit" 
+              class="btn text-violet-900 bg-white"
+            >
+              Create Thread
+            </button>
           </form>
         </Popover.Content>
       </Popover.Portal>
@@ -282,7 +287,7 @@
 
     <Button.Root
       title="Copy invite link"
-      class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150"
+      class="btn"
       onclick={() => {
         navigator.clipboard.writeText(`${page.url.href}`);
       }}

--- a/src/routes/(app)/space/[space]/thread/[ulid]/+page.svelte
+++ b/src/routes/(app)/space/[space]/thread/[ulid]/+page.svelte
@@ -22,7 +22,6 @@
   } from "$lib/schemas/types";
   import type { Autodoc } from "$lib/autodoc/peer";
   import Dialog from "$lib/components/Dialog.svelte";
-  import { isDelete } from "@atproto/api/dist/client/types/com/atproto/repo/applyWrites";
 
   let isMobile = $derived((outerWidth.current ?? 0) < 640);
 

--- a/src/routes/(app)/space/[space]/thread/[ulid]/+page.svelte
+++ b/src/routes/(app)/space/[space]/thread/[ulid]/+page.svelte
@@ -198,7 +198,7 @@
 
   {#if !isMobile}
     <div class="flex">
-      {@render toolbar({ growButton: false })}
+      {@render toolbar()}
     </div>
   {/if}
 </header>
@@ -239,117 +239,47 @@
           </div>
         {/if}
         <div class="relative">
-
-          <!-- TODO: get all users that has joined the server -->
           <ChatInput 
             bind:content={messageInput} 
             users={users.value}
             context={contextItems.value}
             onEnter={sendMessage}
           />
-
-          <!--
-          {#if mayUploadImages}
-            <label
-              class="cursor-pointer text-white hover:text-gray-300 absolute right-3 top-1/2 -translate-y-1/2"
-            >
-              <input
-                type="file"
-                accept="image/*"
-                multiple
-                class="hidden"
-                onchange={handleImageSelect}
-              />
-              <Icon
-                icon="material-symbols:add-photo-alternate"
-                class="text-2xl"
-              />
-            </label>
-          {/if}
-          -->
         </div>
-
-        <!-- Image preview 
-        {#if imageFiles?.length}
-          <div class="flex gap-2 flex-wrap">
-            {#each Array.from(imageFiles) as file}
-              <div class="relative mt-5">
-                <img
-                  src={URL.createObjectURL(file)}
-                  alt={file.name}
-                  class="w-20 h-20 object-cover rounded"
-                />
-                <button
-                  type="button"
-                  class="absolute -top-2 -right-2 bg-red-500 rounded-full p-1"
-                  onclick={() => (imageFiles = null)}
-                >
-                  <Icon icon="zondicons:close-solid" color="white" />
-                </button>
-              </div>
-            {/each}
-          </div>
-        {/if}
-        -->
       </section>
     {/if}
 
     {#if isMobile}
-      {@render toolbar({ growButton: true })}
+      {@render toolbar()}
     {/if}
   </div>
 {/if}
 
-{#snippet toolbar({ growButton = false }: { growButton: boolean })}
-  {#if isThreading.value}
-    <div in:fly class={`${growButton && "grow w-full pr-2"}`}>
-      <Popover.Root>
-        <Popover.Trigger
-          class={`cursor-pointer ${growButton ? "w-full" : "w-fit"} px-4 py-2 rounded bg-violet-800 text-white`}
+{#snippet toolbar()}
+  <menu class="relative flex items-center gap-3 px-2 w-fit self-end">
+    <Popover.Root>
+      <Popover.Trigger onclick={() => isThreading.value = !isThreading.value}>
+        <Icon
+          icon="tabler:needle-thread"
+          color="white"
+          class="text-2xl"
+        />
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content 
+          side="left" 
+          sideOffset={8} 
+          interactOutsideBehavior="ignore" 
+          class="text-white bg-violet-900 rounded p-4"
         >
-          Create Thread
-        </Popover.Trigger>
-
-        <Popover.Content
-          sideOffset={8}
-          forceMount
-          class="bg-violet-800 p-4 rounded"
-        >
-          <form onsubmit={createThread} class="text-white flex flex-col gap-4">
-            <label class="flex flex-col gap-1">
-              Thread Title
-              <input
-                bind:value={threadTitleInput}
-                type="text"
-                placeholder="Notes"
-                class="border px-4 py-2 rounded"
-              />
-            </label>
-            <Popover.Close>
-              <button
-                type="submit"
-                class="text-black px-4 py-2 bg-white rounded w-full text-center"
-              >
-                Confirm
-              </button>
-            </Popover.Close>
+          <form onsubmit={createThread} class="flex flex-col gap-4">
+            <input type="text" bind:value={threadTitleInput} class="bg-violet-800" placeholder="Thread Title" />
+            <button type="submit" class="bg-violet-800 w-full rounded py-2">Create Thread</button>
           </form>
         </Popover.Content>
-      </Popover.Root>
-    </div>
-  {/if}
+      </Popover.Portal>
+    </Popover.Root>
 
-  <menu class="relative flex items-center gap-3 px-2 w-fit self-end">
-    <Toggle.Root
-      bind:pressed={isThreading.value}
-      class={`p-2 ${isThreading.value && "bg-white/10"} cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150 rounded`}
-    >
-      <Icon
-        icon="tabler:needle-thread"
-        color="white"
-        class="text-2xl"
-      />
-    </Toggle.Root>
     <Button.Root
       title="Copy invite link"
       class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150"

--- a/src/routes/(app)/space/[space]/thread/[ulid]/+page.svelte
+++ b/src/routes/(app)/space/[space]/thread/[ulid]/+page.svelte
@@ -1,0 +1,363 @@
+<script lang="ts">
+  import _ from "underscore";
+  import { ulid } from "ulidx";
+  import { page } from "$app/state";
+  import { getContext, setContext } from "svelte";
+  import { goto } from "$app/navigation";
+  import toast from "svelte-french-toast";
+  import { fly } from "svelte/transition";
+  import { user } from "$lib/user.svelte";
+  import { getContentHtml, type Item } from "$lib/tiptap/editor";
+  import { outerWidth } from "svelte/reactivity/window";
+
+  import Icon from "@iconify/svelte";
+  import ChatArea from "$lib/components/ChatArea.svelte";
+  import ChatInput from "$lib/components/ChatInput.svelte";
+  import AvatarImage from "$lib/components/AvatarImage.svelte";
+  import { Button, Popover, Toggle } from "bits-ui";
+
+  import type {
+    Did,
+    Space,
+    Ulid,
+  } from "$lib/schemas/types";
+  import type { Autodoc } from "$lib/autodoc/peer";
+
+  let isMobile = $derived((outerWidth.current ?? 0) < 640);
+
+  let spaceContext = getContext("space") as { get value(): Autodoc<Space> | undefined };
+  let space = $derived(spaceContext.value);
+  let thread = $derived(space?.view.threads[page.params.ulid]);
+  let users: { value: Item[] } = getContext("users");
+  let contextItems: { value: Item[] } = getContext("contextItems");
+
+  let messageInput = $state({});
+  let imageFiles: FileList | null = $state(null);
+
+  // thread maker
+  let isThreading = $state({ value: false });
+  let threadTitleInput = $state("");
+  let selectedMessages: Ulid[] = $state([]);
+  setContext("isThreading", isThreading);
+  setContext("selectMessage", (message: Ulid) => {
+    selectedMessages.push(message);
+  });
+  setContext("removeSelectedMessage", (message: Ulid) => {
+    selectedMessages = selectedMessages.filter((m) => m != message);
+  });
+  setContext("deleteMessage", (message: Ulid) => {
+    if (!space) { return; }
+    space.change((doc) => {
+      // TODO: don't remove from timeline, just delete ID? We need to eventually add a marker
+      // showing the messages is deleted in the timeline.
+      Object.values(doc.channels).forEach((x) => {
+        const idx = x.timeline.indexOf(message);
+        if (idx !== -1) x.timeline.splice(idx, 1);
+      });
+      Object.values(doc.threads).forEach((x) => {
+        const idx = x.timeline.indexOf(message);
+        if (idx !== -1) x.timeline.splice(idx, 1);
+      });
+      delete doc.messages[message];
+    });
+  });
+
+  $effect(() => {
+    if (!isThreading.value && selectedMessages.length > 0) {
+      selectedMessages = [];
+    }
+  });
+
+  // Reply Utils
+  let replyingTo = $state<{
+    id: Ulid;
+    authorProfile: { handle: string; avatarUrl: string };
+    content: string;
+  } | null>();
+
+  setContext(
+    "setReplyTo",
+    (value: {
+      id: Ulid;
+      authorProfile: { handle: string; avatarUrl: string };
+      content: string;
+    }) => {
+      replyingTo = value;
+    },
+  );
+
+  setContext("toggleReaction", (id: Ulid, reaction: string) => {
+    if (!space) return;
+
+    space.change((doc) => {
+      const did = user.profile.data?.did;
+      if (!did) return;
+
+      let reactions = doc.messages[id].reactions[reaction] ?? [];
+
+      if (reactions.includes(did)) {
+        if (doc.messages[id].reactions[reaction].length - 1 === 0) {
+          delete doc.messages[id].reactions[reaction];
+        } else {
+          doc.messages[id].reactions[reaction] = reactions.filter(
+            (actor: Did) => actor !== did,
+          );
+        }
+      } else {
+        if (!doc.messages[id].reactions) {
+          // init reactions object
+          doc.messages[id].reactions = {};
+        }
+        doc.messages[id].reactions[reaction] = [...reactions, did];
+      }
+    });
+  });
+
+  function createThread(e: SubmitEvent) {
+    e.preventDefault();
+    if (!space) return;
+
+    space.change((doc) => {
+      const id = ulid();
+      const timeline = [];
+      for (const id of selectedMessages) {
+        timeline.push(`${id}`);
+      }
+      doc.threads[id] = {
+        title: threadTitleInput,
+        timeline,
+      };
+    });
+
+    threadTitleInput = "";
+    isThreading.value = false;
+    toast.success("Thread created", { position: "bottom-end" });
+  }
+
+  async function sendMessage() {
+    if (!space) return;
+
+    /* TODO: rework with tiptap?
+    const images = imageFiles
+      ? await Promise.all(
+          Array.from(imageFiles).map(async (file) => {
+            try {
+              const resp = await user.uploadBlob(file);
+              return {
+                source: resp.url, // Use the blob reference from ATP
+                alt: file.name,
+              };
+            } catch (error) {
+              console.error("Failed to upload image:", error);
+              toast.error("Failed to upload image", { position: "bottom-end" });
+              return null;
+            }
+          }),
+        ).then((results) =>
+          results.filter(
+            (result): result is NonNullable<typeof result> => result !== null,
+          ),
+        )
+      : undefined;
+    */
+
+    space.change((doc) => {
+      if (!user.agent) return;
+
+      const id = ulid();
+      doc.messages[id] = {
+        author: user.agent.assertDid,
+        reactions: {},
+        content: JSON.stringify(messageInput),
+        ...(replyingTo && { replyTo: replyingTo.id }),
+      };
+      doc.threads[page.params.ulid].timeline.push(id);
+    });
+
+    messageInput = {};
+    replyingTo = null;
+    imageFiles = null;
+  }
+</script>
+
+<header class="flex flex-none items-center justify-between border-b-1 pb-4">
+  <div class="flex gap-4 items-center">
+    {#if isMobile}
+      <Button.Root onclick={() => goto(`/space/${page.params.space}`)}>
+        <Icon icon="uil:left" color="white" />
+      </Button.Root>
+    {:else}
+      <AvatarImage handle={thread?.title ?? ""} />
+    {/if}
+
+    <h4 class={`${isMobile && "line-clamp-1 overflow-hidden text-ellipsis"} text-white text-lg font-bold`}>
+      {thread?.title}
+    </h4>
+  </div>
+
+
+  {#if !isMobile}
+    <div class="flex">
+      {@render toolbar({ growButton: false })}
+    </div>
+  {/if}
+</header>
+
+{#if space}
+  <ChatArea
+    source={{ type: "space", space: space }}
+    timeline={thread?.timeline ?? []}
+  />
+  <div class="flex float-end">
+    {#if !isMobile || !isThreading.value}
+      <section class="grow flex flex-col">
+        {#if replyingTo}
+          <div
+            class="flex justify-between bg-violet-800 text-white rounded-t-lg px-4 py-2"
+          >
+            <div class="flex flex-col gap-1">
+              <h5 class="flex gap-2 items-center">
+                Replying to
+                <AvatarImage
+                  handle={replyingTo.authorProfile.handle}
+                  avatarUrl={replyingTo.authorProfile.avatarUrl}
+                  className="!w-4"
+                />
+                <strong>{replyingTo.authorProfile.handle}</strong>
+              </h5>
+              <p class="text-gray-300 text-ellipsis italic">
+                {@html getContentHtml(replyingTo.content)}
+              </p>
+            </div>
+            <Button.Root
+              type="button"
+              onclick={() => (replyingTo = null)}
+              class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150"
+            >
+              <Icon icon="zondicons:close-solid" />
+            </Button.Root>
+          </div>
+        {/if}
+        <div class="relative">
+
+          <!-- TODO: get all users that has joined the server -->
+          <ChatInput 
+            bind:content={messageInput} 
+            users={users.value}
+            context={contextItems.value}
+            onEnter={sendMessage}
+          />
+
+          <!--
+          {#if mayUploadImages}
+            <label
+              class="cursor-pointer text-white hover:text-gray-300 absolute right-3 top-1/2 -translate-y-1/2"
+            >
+              <input
+                type="file"
+                accept="image/*"
+                multiple
+                class="hidden"
+                onchange={handleImageSelect}
+              />
+              <Icon
+                icon="material-symbols:add-photo-alternate"
+                class="text-2xl"
+              />
+            </label>
+          {/if}
+          -->
+        </div>
+
+        <!-- Image preview 
+        {#if imageFiles?.length}
+          <div class="flex gap-2 flex-wrap">
+            {#each Array.from(imageFiles) as file}
+              <div class="relative mt-5">
+                <img
+                  src={URL.createObjectURL(file)}
+                  alt={file.name}
+                  class="w-20 h-20 object-cover rounded"
+                />
+                <button
+                  type="button"
+                  class="absolute -top-2 -right-2 bg-red-500 rounded-full p-1"
+                  onclick={() => (imageFiles = null)}
+                >
+                  <Icon icon="zondicons:close-solid" color="white" />
+                </button>
+              </div>
+            {/each}
+          </div>
+        {/if}
+        -->
+      </section>
+    {/if}
+
+    {#if isMobile}
+      {@render toolbar({ growButton: true })}
+    {/if}
+  </div>
+{/if}
+
+{#snippet toolbar({ growButton = false }: { growButton: boolean })}
+  {#if isThreading.value}
+    <div in:fly class={`${growButton && "grow w-full pr-2"}`}>
+      <Popover.Root>
+        <Popover.Trigger
+          class={`cursor-pointer ${growButton ? "w-full" : "w-fit"} px-4 py-2 rounded bg-violet-800 text-white`}
+        >
+          Create Thread
+        </Popover.Trigger>
+
+        <Popover.Content
+          sideOffset={8}
+          forceMount
+          class="bg-violet-800 p-4 rounded"
+        >
+          <form onsubmit={createThread} class="text-white flex flex-col gap-4">
+            <label class="flex flex-col gap-1">
+              Thread Title
+              <input
+                bind:value={threadTitleInput}
+                type="text"
+                placeholder="Notes"
+                class="border px-4 py-2 rounded"
+              />
+            </label>
+            <Popover.Close>
+              <button
+                type="submit"
+                class="text-black px-4 py-2 bg-white rounded w-full text-center"
+              >
+                Confirm
+              </button>
+            </Popover.Close>
+          </form>
+        </Popover.Content>
+      </Popover.Root>
+    </div>
+  {/if}
+
+  <menu class="relative flex items-center gap-3 px-2 w-fit self-end">
+    <Toggle.Root
+      bind:pressed={isThreading.value}
+      class={`p-2 ${isThreading.value && "bg-white/10"} cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150 rounded`}
+    >
+      <Icon
+        icon="tabler:needle-thread"
+        color="white"
+        class="text-2xl"
+      />
+    </Toggle.Root>
+    <Button.Root
+      title="Copy invite link"
+      class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150"
+      onclick={() => {
+        navigator.clipboard.writeText(`${page.url.href}`);
+      }}
+    >
+      <Icon icon="icon-park-outline:copy-link" color="white" class="text-2xl" />
+    </Button.Root>
+  </menu>
+{/snippet}


### PR DESCRIPTION
Implements a new Threads UX where users now "move" messages from a channel (or thread)'s timeline to a new 'Thread' timeline available Space-wide.

- Threads now live under the `/space/[space]/thread/[thread]` URL, not attached to a specific channel 
- Threads now have a `relatedChannel` field to know it's origin, threads made from existing threads will have the same `relatedChannel`
- Users can navigate to threads using the sidebar alongside the channel selector, alongside the existing Chat/Threads tabs
- Update the sidebar on URL change, highlighting the current channel/thread
- Implements a new timeline event type called `Announcements` which shows a change to the Space; this PR implements the `threadCreated` and `messageMoved` announcement types
- Changes and refactor to `ChatMessage` to render Announcements using custom Prosemirror schema objects; render `messageMoved` announcement similar to a reply banner
- `Message`, `Announcement`, `Channel`, and `Thread` types now have a `softDelete` field; any "delete" now changes this field to true and will tell the client to not render it, though it still exists in the document. Admins will be the only ones available to permanently delete objects from the document (to be implemented)
- Space layout now keeps track of a `contextItems` array, which will be available to mention extensions to ensure that any soft deleted threads and channels will not show up to users
- Fix 'Create Thread' popup component anchoring

Closes #40 
Closes #83
Closes #82 

https://github.com/user-attachments/assets/d818884f-8959-4abf-8204-d661d22cc8b8