### PR TITLE
fix: scroll to end of channel when chatting.

### DIFF
--- a/src/lib/components/ChatArea.svelte
+++ b/src/lib/components/ChatArea.svelte
@@ -11,6 +11,7 @@
     type Timeline,
   } from "@roomy-chat/sdk";
   import { derivePromise } from "$lib/utils.svelte";
+  import { page } from "$app/state";
 
   let {
     timeline,
@@ -34,22 +35,13 @@
   let viewport: HTMLDivElement = $state(null!);
   let virtualizer: Virtualizer<string> | undefined = $state();
 
-  // Go to the end of the ScrollArea
-  let scrollToEnd = $state(true);
-  onNavigate(() => {
-    setTimeout(() => {
-      if (virtualizer) virtualizer.scrollToIndex(messages.value.length - 1);
-    }, 100);
-  });
-
   $effect(() => {
-    scrollToEnd = true;
+    page.route; // Scroll-to-end when route changes
+    messages.value; // Scroll to end when message list changes.
     if (viewport) {
-      viewport.scrollTop = viewport.scrollHeight;
       setTimeout(() => {
         if (virtualizer) virtualizer.scrollToIndex(messages.value.length - 1);
-      }, 100);
-      scrollToEnd = false;
+      });
     }
   });
 </script>


### PR DESCRIPTION
Still needs work, but it's better than nothing right now.

Future improvements include:

- Not scrolling to the bottom when somebody chats if you are scrolled back in history
- Remembering your last scroll position in different channels instead of just scrolling to the bottom every time you click to a new channel ( but also only doing that if you are scrolled high enough in history ).