### PR TITLE
Fix: adds ability to auto-focus elements and improves wiki deletion

### DIFF
--- a/src/lib/actions/useFocusOnRender.svelte.ts
+++ b/src/lib/actions/useFocusOnRender.svelte.ts
@@ -1,0 +1,19 @@
+import { tick } from "svelte";
+
+/**
+ * Svelte action to focus an element after it is rendered.
+ * Add use:focusOnRender to HTML element to focus it after it is rendered.
+ * @param elementRef The HTML element to focus.
+ */
+export function focusOnRender(elementRef: HTMLElement | null) {
+  async function update() {
+    await tick(); // Wait for the DOM to update
+    if (elementRef) {
+      // Wait another tick.
+      // This is necessary to ensure that the element is fully rendered.
+      tick().then(() => elementRef.focus());
+    }
+  }
+
+  update();
+}

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -5,7 +5,7 @@
 
   type Props = {
     title: string;
-    description?: string;
+    description?: string; // may be formatted with HTML
     isDialogOpen?: boolean;
     disabled?: boolean;
     dialogTrigger?: Snippet;
@@ -54,7 +54,8 @@
 
         {#if description}
           <Dialog.Description class="text-sm">
-            {description}
+            <!-- allows text to be formed with HTML -->
+            {@html description}
           </Dialog.Description>
         {/if}
 

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -8,7 +8,7 @@
     description?: string;
     isDialogOpen?: boolean;
     disabled?: boolean;
-    dialogTrigger: Snippet;
+    dialogTrigger?: Snippet;
     children?: Snippet;
   };
 
@@ -23,14 +23,21 @@
 </script>
 
 <Dialog.Root bind:open={isDialogOpen}>
-  <Dialog.Trigger {disabled}>
-    {@render dialogTrigger()}
-  </Dialog.Trigger>
+  {#if dialogTrigger}
+    <Dialog.Trigger {disabled}>
+      {@render dialogTrigger()}
+    </Dialog.Trigger>
+  {/if}
   <Dialog.Portal>
     <Dialog.Overlay class="fixed inset-0 z-50 bg-black/80" />
 
     <Dialog.Content
       class="fixed flex flex-col gap-4 p-4 w-dvw max-w-(--breakpoint-sm) left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]"
+      onkeydown={(e) => {
+        if (e.key === "Escape") {
+          isDialogOpen = false;
+        }
+      }}
     >
       <div class="p-5 bg-base-200 rounded-box flex flex-col gap-3">
         <div class="flex flex-col gap-3">

--- a/src/lib/components/WikiEditor.svelte
+++ b/src/lib/components/WikiEditor.svelte
@@ -218,6 +218,9 @@
     if (wikiToDelete) {
       wikiToDelete.softDeleted = true;
       wikiToDelete.commit();
+
+      isEditingWiki = false; // Close the editor to remove cached wiki
+      selectedWiki = wikis.value[0]; // Select the first wiki after deletion
     }
     isDeleteDialogOpen = false;
     wikiToDelete = undefined;
@@ -810,7 +813,7 @@
               : ''}"
           >
             <div
-              class="flex justify-between items-center group"
+              class="flex justify-between items-center group relative"
               onclick={() => selectWiki(wiki)}
               role="button"
               tabindex="0"
@@ -821,15 +824,14 @@
               }}
             >
               <span>{wiki.name}</span>
-
-              <div class="delete-container">
+              {#if g.isAdmin}
                 <button
-                  class="btn btn-error btn-xs delete-button hidden group-hover:block"
+                  class="absolute right-0 btn btn-error btn-xs delete-button hidden group-hover:block"
                   onclick={(e) => showDeleteDialog(wiki, e)}
                 >
                   <Icon icon="tabler:trash" />
                 </button>
-              </div>
+              {/if}
             </div>
           </li>
         {/if}
@@ -845,7 +847,7 @@
       >
         <p class="text-base-content/70">No wiki pages.</p>
       </div>
-    {:else if isEditingWiki}
+    {:else if isEditingWiki && !selectedWiki.softDeleted}
       <section class="wiki-editor-container">
         <div class="mb-4 flex justify-between items-center">
           <input

--- a/src/lib/components/WikiEditor.svelte
+++ b/src/lib/components/WikiEditor.svelte
@@ -1092,7 +1092,7 @@
 
 <Dialog
   title="Confirm Wiki Deletion"
-  description="Are you sure you want to delete <b>{wikiToDelete?.name}</b>?"
+  description="Are you sure you want to delete <b>{wikiToDelete?.name}</b>?</br></br><b>Note:</b> Deletes are not permanent and only hide the data from view. The data is still publicly accessible."
   bind:isDialogOpen={isDeleteDialogOpen}
 >
   <div class="flex justify-end gap-3">

--- a/src/lib/components/WikiEditor.svelte
+++ b/src/lib/components/WikiEditor.svelte
@@ -793,7 +793,7 @@
 
 <!-- NEW: Two-column layout for multiple wikis -->
 <div class="flex h-full overflow-y-auto">
-  <aside class="w-1/4 border-r p-4">
+  <aside class="w-1/4 border-r border-base-content/10 p-4">
     <div class="mb-4 flex justify-between items-center">
       <h3 class="text-xl font-bold text-base-content">Wikis</h3>
       <button class="btn btn-primary btn-sm text-lg" onclick={createWiki}>

--- a/src/lib/components/WikiEditor.svelte
+++ b/src/lib/components/WikiEditor.svelte
@@ -150,7 +150,7 @@
 
   let isWikiTitleDialogOpen = $state(false);
   let newWikiTitleElement: HTMLInputElement | null = $state(null);
-  let deleteDialogVisible = $state(false);
+  let isDeleteDialogOpen = $state(false);
   let wikiToDelete: WikiPage | undefined = $state();
 
   function selectWiki(wiki: any) {
@@ -211,7 +211,7 @@
   function showDeleteDialog(wiki: any, event: Event) {
     event.stopPropagation();
     wikiToDelete = wiki;
-    deleteDialogVisible = true;
+    isDeleteDialogOpen = true;
   }
 
   function confirmDeleteWiki() {
@@ -219,12 +219,7 @@
       wikiToDelete.softDeleted = true;
       wikiToDelete.commit();
     }
-    deleteDialogVisible = false;
-    wikiToDelete = undefined;
-  }
-
-  function cancelDeleteWiki() {
-    deleteDialogVisible = false;
+    isDeleteDialogOpen = false;
     wikiToDelete = undefined;
   }
 
@@ -826,16 +821,15 @@
               }}
             >
               <span>{wiki.name}</span>
-              {#if g.isAdmin}
-                <div class="delete-container">
-                  <button
-                    class="btn btn-error btn-xs delete-button hidden group-hover:block"
-                    onclick={(e) => showDeleteDialog(wiki, e)}
-                  >
-                    <Icon icon="tabler:trash" />
-                  </button>
-                </div>
-              {/if}
+
+              <div class="delete-container">
+                <button
+                  class="btn btn-error btn-xs delete-button hidden group-hover:block"
+                  onclick={(e) => showDeleteDialog(wiki, e)}
+                >
+                  <Icon icon="tabler:trash" />
+                </button>
+              </div>
             </div>
           </li>
         {/if}
@@ -1088,27 +1082,15 @@
   </form>
 </Dialog>
 
-{#if deleteDialogVisible}
-  <div
-    class="fixed inset-0 bg-black/50 flex items-center justify-center z-[120]"
-  >
-    <div
-      class="bg-base-300 border border-base-content/20 rounded-lg shadow-lg p-6 max-w-md w-full"
-    >
-      <h3 class="text-lg font-bold text-base-content mb-4">Confirm Deletion</h3>
-      <p class="mb-4 text-base-content">
-        Are you sure you want to delete this wiki: {wikiToDelete?.name}?
-      </p>
-      <div class="flex justify-end gap-3">
-        <button class="btn btn-outline" onclick={cancelDeleteWiki}
-          >Cancel</button
-        >
-        <button class="btn btn-error" onclick={confirmDeleteWiki}>Delete</button
-        >
-      </div>
-    </div>
+<Dialog
+  title="Confirm Wiki Deletion"
+  description="Are you sure you want to delete <b>{wikiToDelete?.name}</b>?"
+  bind:isDialogOpen={isDeleteDialogOpen}
+>
+  <div class="flex justify-end gap-3">
+    <button class="btn btn-error" onclick={confirmDeleteWiki}>Delete</button>
   </div>
-{/if}
+</Dialog>
 
 <style>
   :global(.bn-block) {

--- a/src/lib/components/WikiEditor.svelte
+++ b/src/lib/components/WikiEditor.svelte
@@ -1,14 +1,9 @@
 <script lang="ts">
   import { onMount, getContext, tick } from "svelte";
   import { codeToHtml } from "shiki";
-  import { BlockNoteEditor } from "@blocknote/core";
-  import "@blocknote/core/style.css";
-  import { onMount } from "svelte";
   import { toast } from "svelte-french-toast";
   import { Button } from "bits-ui";
   import Icon from "@iconify/svelte";
-  import { page } from "$app/state";
-  import { getContext } from "svelte";
   import Link from "@tiptap/extension-link";
   import { BlockNoteEditor } from "@blocknote/core";
   import "@blocknote/core/style.css";
@@ -818,9 +813,18 @@
             selectedWiki?.id
               ? 'bg-base-200'
               : ''}"
-            onclick={() => selectWiki(wiki)}
           >
-            <div class="flex justify-between items-center group">
+            <div
+              class="flex justify-between items-center group"
+              onclick={() => selectWiki(wiki)}
+              role="button"
+              tabindex="0"
+              onkeydown={(e) => {
+                if (e.key === "Enter") {
+                  selectWiki(wiki);
+                }
+              }}
+            >
               <span>{wiki.name}</span>
               {#if g.isAdmin}
                 <div class="delete-container">

--- a/src/lib/components/WikiEditor.svelte
+++ b/src/lib/components/WikiEditor.svelte
@@ -17,10 +17,11 @@
   import Dialog from "$lib/components/Dialog.svelte";
 
   const wikis = derivePromise([], async () => {
-    return g.space && g.channel && g.channel instanceof Channel
+    return g.space && g.channel instanceof Channel
       ? (await g.channel.wikipages.items()).filter((x) => !x.softDeleted)
       : [];
   });
+
   let selectedWiki: WikiPage | undefined = $state(wikis.value[0]);
   $effect(() => {
     if (wikis.value.length > 0 && !selectedWiki) {
@@ -220,7 +221,7 @@
       wikiToDelete.commit();
 
       isEditingWiki = false; // Close the editor to remove cached wiki
-      selectedWiki = wikis.value[0]; // Select the first wiki after deletion
+      selectedWiki = undefined;
     }
     isDeleteDialogOpen = false;
     wikiToDelete = undefined;
@@ -695,6 +696,7 @@
   $effect(() => {
     if (!selectedWiki || selectedWiki.bodyJson == "{}") {
       wikiRenderedHtml = "";
+      processedHtml = "";
       return;
     }
     const json = JSON.parse(selectedWiki.bodyJson);
@@ -1036,7 +1038,11 @@
         </div>
         <div class="wiki-rendered p-4 bg-base-300/30 rounded-lg">
           <div class="wiki-html text-base-content">
-            {@html processedHtml}
+            {#if selectedWiki && !selectedWiki.softDeleted}
+              {@html processedHtml}
+            {:else}
+              <p class="text-base-content/70">No content available.</p>
+            {/if}
           </div>
         </div>
       </section>


### PR DESCRIPTION
In between mobile updates, I got mad at the auto focus not working correctly so I decided to fix it. There are a couple of general component fixes in this PR. Who was the one that told me Svelte was so nice again? 👀 I feel so sloooow.

- [x] Allows Esc to close on all <Dialogs> 🗑️ 
- [x] New Svelte action for focusing an html element
- [x] Improves wiki deletion for admins

### Small aesthetic wiki tab related tweaks
- [x] Wiki list/editor vertical divider now matches theme
- [x] Delete button for single wiki no longer makes text jump when appearing
- [x] Cancel buttons were removed since <Dialog> has it's own way to cancel
- [x] Editor is closed automatically when deleting and user is taken to first wiki in the list
- [x] Improved data checks

> [!CAUTION]
> We're still leaking some data here somehow. We should only be returning data that hasn't been deleted from the server rather than filtering it on the client. 


## Demo
https://github.com/user-attachments/assets/7aa57260-7e57-4a02-ad35-16165663493d

