### PR TITLE
Fix: user session out-of-date

### DIFF
--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -7,6 +7,7 @@
     title: string;
     description?: string;
     isDialogOpen?: boolean;
+    disabled?: boolean;
     dialogTrigger: Snippet;
     children?: Snippet;
   };
@@ -15,13 +16,14 @@
     title,
     description,
     isDialogOpen = $bindable<boolean>(false),
+    disabled,
     dialogTrigger,
     children,
   }: Props = $props();
 </script>
 
 <Dialog.Root bind:open={isDialogOpen}>
-  <Dialog.Trigger>
+  <Dialog.Trigger {disabled}>
     {@render dialogTrigger()}
   </Dialog.Trigger>
   <Dialog.Portal>

--- a/src/lib/stores/dialog.ts
+++ b/src/lib/stores/dialog.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const isLoginDialogOpen = writable(false);

--- a/src/lib/stores/dialog.ts
+++ b/src/lib/stores/dialog.ts
@@ -1,3 +1,0 @@
-import { writable } from "svelte/store";
-
-export const isLoginDialogOpen = writable(false);

--- a/src/lib/user.svelte.ts
+++ b/src/lib/user.svelte.ts
@@ -12,6 +12,9 @@ import { IN_TAURI } from "./tauri";
 import { page } from "$app/state";
 import { navigate } from "$lib/utils.svelte";
 
+// TODO: add proper Tauri type definitions.
+declare let window: Window & { __TAURI__: any };
+
 // Reload app when this module changes to prevent accumulated connections
 if (import.meta.hot) {
   import.meta.hot.accept(() => {
@@ -103,8 +106,17 @@ let catalogId: {
   };
 });
 
+let isLoginDialogOpen = $state(false);
+
 /** The user store. */
 export const user = {
+  get isLoginDialogOpen() {
+    return isLoginDialogOpen;
+  },
+  set isLoginDialogOpen(value) {
+    isLoginDialogOpen = value;
+  },
+
   /**
    * The AtProto agent that can be used to interact with the AtProto API
    * through the user's login.
@@ -191,9 +203,9 @@ export const user = {
       const { onOpenUrl } = window.__TAURI__.deepLink;
 
       openUrl(url);
-      await onOpenUrl((urls) => {
+      await onOpenUrl((urls: string[]) => {
         if (!urls || urls.length < 1) return;
-        const url = new URL(urls[0]);
+        const url = new URL(urls[0]!);
         const path = page.url;
 
         path.search = url.search;

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -16,7 +16,6 @@
   import ThemeSelector from "$lib/components/ThemeSelector.svelte";
   import { Space } from "@roomy-chat/sdk";
   import SidebarSpace from "$lib/components/SidebarSpace.svelte";
-  import { isLoginDialogOpen } from "$lib/stores/dialog";
 
   const { children } = $props();
 
@@ -34,7 +33,7 @@
   onMount(async () => {
     await user.init();
     if (!user.session) {
-      $isLoginDialogOpen = true;
+      user.isLoginDialogOpen = true;
     }
   });
 
@@ -140,7 +139,7 @@
         description={user.session
           ? `Logged in as ${user.profile.data?.handle}`
           : "Log in with AT Protocol"}
-        bind:isDialogOpen={$isLoginDialogOpen}
+        bind:isDialogOpen={user.isLoginDialogOpen}
       >
         {#snippet dialogTrigger()}
           <Button.Root class="btn btn-ghost w-fit">

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import "../../app.css";
   import { onMount } from "svelte";
+  import { Toaster } from "svelte-french-toast";
+  import { RenderScan } from "svelte-render-scan";
+  import { Button, ToggleGroup } from "bits-ui";
+
   import { dev } from "$app/environment";
   import { g } from "$lib/global.svelte";
   import { user } from "$lib/user.svelte";
@@ -9,20 +13,15 @@
   import Icon from "@iconify/svelte";
   import Dialog from "$lib/components/Dialog.svelte";
   import AvatarImage from "$lib/components/AvatarImage.svelte";
-
-  import { Toaster } from "svelte-french-toast";
-  import { RenderScan } from "svelte-render-scan";
-  import { Button, ToggleGroup, Avatar } from "bits-ui";
-
   import ThemeSelector from "$lib/components/ThemeSelector.svelte";
   import { Space } from "@roomy-chat/sdk";
   import SidebarSpace from "$lib/components/SidebarSpace.svelte";
+  import { isLoginDialogOpen } from "$lib/stores/dialog";
 
   const { children } = $props();
 
   let handleInput = $state("");
   let loginLoading = $state(false);
-  let isLoginDialogOpen = $state(!user.session);
 
   let newSpaceName = $state("");
   let isNewSpaceDialogOpen = $state(false);
@@ -34,10 +33,9 @@
 
   onMount(async () => {
     await user.init();
-  });
-
-  $effect(() => {
-    if (user.session) isLoginDialogOpen = false;
+    if (!user.session) {
+      $isLoginDialogOpen = true;
+    }
   });
 
   async function createSpace() {
@@ -112,9 +110,14 @@
         title="Create Space"
         description="Create a new public chat space"
         bind:isDialogOpen={isNewSpaceDialogOpen}
+        disabled={!user.session}
       >
         {#snippet dialogTrigger()}
-          <Button.Root title="Create Space" class="btn btn-ghost w-fit">
+          <Button.Root
+            title="Create Space"
+            class="btn btn-ghost w-fit"
+            disabled={!user.session}
+          >
             <Icon icon="basil:add-solid" font-size="2em" />
           </Button.Root>
         {/snippet}
@@ -137,7 +140,7 @@
         description={user.session
           ? `Logged in as ${user.profile.data?.handle}`
           : "Log in with AT Protocol"}
-        bind:isDialogOpen={isLoginDialogOpen}
+        bind:isDialogOpen={$isLoginDialogOpen}
       >
         {#snippet dialogTrigger()}
           <Button.Root class="btn btn-ghost w-fit">

--- a/src/routes/(app)/home/+page.svelte
+++ b/src/routes/(app)/home/+page.svelte
@@ -5,7 +5,6 @@
   import { g } from "$lib/global.svelte";
   import { user } from "$lib/user.svelte";
   import { derivePromise } from "$lib/utils.svelte";
-  import { isLoginDialogOpen } from "$lib/stores/dialog";
 
   const spaces = derivePromise(
     undefined,
@@ -28,7 +27,7 @@
 
       {#if !user.session}
         <Button.Root
-          onclick={() => ($isLoginDialogOpen = true)}
+          onclick={() => (user.isLoginDialogOpen = true)}
           class="btn btn-primary"
         >
           Log In with Bluesky

--- a/src/routes/(app)/home/+page.svelte
+++ b/src/routes/(app)/home/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
-  import { g } from "$lib/global.svelte";
-  import { derivePromise } from "$lib/utils.svelte";
   import Icon from "@iconify/svelte";
+  import { Button } from "bits-ui";
+
+  import { g } from "$lib/global.svelte";
+  import { user } from "$lib/user.svelte";
+  import { derivePromise } from "$lib/utils.svelte";
+  import { isLoginDialogOpen } from "$lib/stores/dialog";
 
   const spaces = derivePromise(
     undefined,
@@ -22,7 +26,14 @@
       </p>
       <div class="divider"></div>
 
-      {#if !spaces.value}
+      {#if !user.session}
+        <Button.Root
+          onclick={() => ($isLoginDialogOpen = true)}
+          class="btn btn-primary"
+        >
+          Log In with Bluesky
+        </Button.Root>
+      {:else if !spaces.value}
         <span class="loading loading-spinner mx-auto w-25"></span>
       {:else if spaces.value.length > 0}
         <h2 class="text-3xl font-bold">Your Spaces</h2>
@@ -44,6 +55,10 @@
             </a>
           {/each}
         </section>
+      {:else if spaces.value.length === 0}
+        <p class="text-lg font-medium text-center">
+          You don't have any spaces yet. Create one to get started!
+        </p>
       {:else}
         <p>No servers found.</p>
       {/if}


### PR DESCRIPTION
Turns out we weren't correctly awaiting out atproto call in our user.init() function. This now returns correctly after the call finishes which allows us to remove an effect 🎉 (always a win!). Looking at the user object, I also cleaned up the cases where we lose the user.session to keep the user in a cleaner state.


### More obvious log in button
_Just in case they miss the auto-dialog (which now works more consistently)_

![new-log-in-button](https://github.com/user-attachments/assets/27d23b4c-5b59-4221-b5d5-08987b65f31a)

### Log in doesn't refresh and flash multiple times
_Still room for improvement here. A loading state probably makes sense._

![cleaner-log-in](https://github.com/user-attachments/assets/d2c7d167-93af-401d-a897-762b09ad600b)

### Redirect user to home on log out
![log-out-correctly](https://github.com/user-attachments/assets/415faf41-a0c2-46c7-8157-0321f62faa32)
