### PR TITLE
fix: displays emoji panel above chat / input placeholder shows cursor

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -35,7 +35,7 @@ emoji-picker {
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
-  @apply hover:scale-[101%] active:scale-95
+  @apply hover:scale-[101%] active:scale-95;
 }
 
 /* TipTap Nodes */
@@ -43,9 +43,9 @@ emoji-picker {
 .mention {
   background-color: var(--color-accent);
   color: var(--color-accent-content);
-  padding-top: 0.125rem; 
+  padding-top: 0.125rem;
   padding-bottom: 0.125rem;
-  padding-left: 0.5rem; 
+  padding-left: 0.5rem;
   padding-right: 0.5rem;
   border-radius: 0.25rem;
   font-style: normal !important;

--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -52,9 +52,6 @@
     tiptap = new Editor({
       element,
       extensions,
-      content: untrack(() =>
-        content.type ? content : { type: "doc", children: [] },
-      ),
       editorProps: {
         attributes: {
           class:

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -227,7 +227,7 @@
           >
             <Icon icon="lucide:smile-plus" color="white" />
           </Popover.Trigger>
-          <Popover.Content>
+          <Popover.Content class="z-10">
             <emoji-picker bind:this={emojiRowPicker}></emoji-picker>
           </Popover.Content>
         </Popover.Root>
@@ -391,7 +391,7 @@
             <Popover.Trigger class="btn btn-circle">
               <Icon icon="lucide:smile-plus" />
             </Popover.Trigger>
-            <Popover.Content>
+            <Popover.Content class="z-10">
               <emoji-picker bind:this={emojiDrawerPicker}></emoji-picker>
             </Popover.Content>
           </Popover.Root>
@@ -443,7 +443,7 @@
           <Popover.Trigger class="btn btn-ghost btn-square">
             <Icon icon="lucide:smile-plus" />
           </Popover.Trigger>
-          <Popover.Content>
+          <Popover.Content class="z-10">
             <emoji-picker bind:this={emojiToolbarPicker}></emoji-picker>
           </Popover.Content>
         </Popover.Root>


### PR DESCRIPTION
fixes: #162 

### Emoji panels now show above chat
![Screenshot 2025-04-15 013810](https://github.com/user-attachments/assets/eca9a6f5-8802-4fc0-b3b3-2d5998005872)

![Screenshot 2025-04-15 013757](https://github.com/user-attachments/assets/46013375-f5c9-420d-a280-0a7c384e8954)


### Placeholder now loads on mount correctly and doesn't disappear
![image](https://github.com/user-attachments/assets/7b7419ff-0820-4594-8eda-3ddcfc46d687)
