### PR TITLE
don't auto show modal

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -2,12 +2,12 @@
   import "../../app.css";
   import { onMount } from "svelte";
   import { browser, dev } from "$app/environment";
-  
+
   import posthog from "posthog-js";
   import { Toaster } from "svelte-french-toast";
   import { RenderScan } from "svelte-render-scan";
   import { Button, ToggleGroup } from "bits-ui";
-  
+
   import { g } from "$lib/global.svelte";
   import { user } from "$lib/user.svelte";
   import { cleanHandle, derivePromise, navigate } from "$lib/utils.svelte";
@@ -43,11 +43,7 @@
     }
   });
 
-  $effect(() => {
-    if (!user.session) {
-      user.isLoginDialogOpen = true;
-    }
-  });
+  // Removed auto-popup effect to only show login dialog when user clicks avatar
 
   async function createSpace() {
     if (!newSpaceName || !user.agent || !g.roomy) return;


### PR DESCRIPTION
looks like there is a regression where login modal is showing even if already logged in. removing modal unless user clicks on avatar. we have a "log in with bluesky" button already on page if they aren't logged in that will trigger modal