### PR TITLE
chore: remove theme storage in cookie

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -2,19 +2,20 @@ import { themes } from "$lib/themes";
 import type { Handle, HandleClientError } from "@sveltejs/kit";
 import posthog from "posthog-js";
 
-export const handle: Handle = async ({ event, resolve }) => {
-  const theme = event.cookies.get("theme");
-  if (!theme || !themes.includes(theme)) {
-    event.cookies.set("theme", "retro", { path: "/" });
-    return await resolve(event);
-  }
+// We're handling this in ThemeSelector.svelte
+// export const handle: Handle = async ({ event, resolve }) => {
+//   const theme = event.cookies.get("theme");
+//   if (!theme || !Object.keys(themes).includes("data-theme=${theme}")) {
+//     event.cookies.set("theme", "synthwave", { path: "/" });
+//     return await resolve(event);
+//   }
 
-  return await resolve(event, {
-    transformPageChunk: ({ html }) => {
-      return html.replace('data-theme=""', `data-theme="${theme}"`);
-    },
-  });
-};
+//   return await resolve(event, {
+//     transformPageChunk: ({ html }) => {
+//       return html.replace('data-theme=""', `data-theme="${theme}"`);
+//     },
+//   });
+// };
 
 export const handleError: HandleClientError = async ({
   error,

--- a/src/lib/components/ThemeSelector.svelte
+++ b/src/lib/components/ThemeSelector.svelte
@@ -4,7 +4,6 @@
   import Icon from "@iconify/svelte";
 
   let currentTheme = $state("");
-  let previewTheme = $state("");
 
   // Extract theme names and color values from the themes object
   function getThemeName(selector: string): string {
@@ -85,10 +84,8 @@
 
   function setTheme(theme: string) {
     window.localStorage.setItem("theme", theme);
-    document.cookie = `theme=${theme}; path=/`;
     document.documentElement.setAttribute("data-theme", theme);
     currentTheme = theme;
-    previewTheme = "";
   }
 </script>
 


### PR DESCRIPTION
We already store the theme in local storage, so I don't think the cookie is necessary. The default was also being set to something different, then overridden in another place.