### PR TITLE
fix: adds correct redirect for initial load from server

### DIFF
--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -1,0 +1,6 @@
+import { redirect } from "@sveltejs/kit";
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = () => {
+  throw redirect(302, "/home");
+};

--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -1,6 +1,0 @@
-import { redirect } from "@sveltejs/kit";
-import type { PageServerLoad } from "./$types";
-
-export const load: PageServerLoad = () => {
-  throw redirect(302, "/home");
-};

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1,3 +1,8 @@
 <script lang="ts">
-  window.location.href = "/home";
+  import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
+
+  onMount(async () => {
+    await goto("/home", { replaceState: true });
+  });
 </script>

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
 
-  onMount(async () => {
-    await goto("/home", { replaceState: true });
+  onMount(() => {
+    goto("/home", { replaceState: true });
   });
 </script>


### PR DESCRIPTION
Because we redirect users to home immediately, Firefox (for me) would render the page twice and cause a gross-looking browser style *hiccup*. This fixes it. The page should load quicker now for users on browsers outside of chrome which seemed to handle this correctly by default.