### PR TITLE
chore: fix netlify SPA redirect broken after adding Posthog redirect.

### DIFF
--- a/scripts/netlify_build.sh
+++ b/scripts/netlify_build.sh
@@ -34,4 +34,5 @@ echo "{
 echo '
 /ingest/static/*  https://us-assets.i.posthog.com/static/:splat  200!
 /ingest/*         https://us.i.posthog.com/:splat  200!
+/* /index.html 200
 ' > dist/_redirects


### PR DESCRIPTION
The previous commit adding Netlify redirects for Posthog apparently overwrote a default redirect rule that Netlify needs to apply to properly route SPAs. This adds an SPA routing rule.