### PR TITLE
chore: put the netlify redirects in static folder instead of in build script.

### DIFF
--- a/scripts/netlify_build.sh
+++ b/scripts/netlify_build.sh
@@ -30,9 +30,3 @@ echo "{
   \"application_type\": \"web\",
   \"dpop_bound_access_tokens\": true
 }" > dist/oauth-client.json
-
-echo '
-/ingest/static/*  https://us-assets.i.posthog.com/static/:splat  200!
-/ingest/*         https://us.i.posthog.com/:splat  200!
-/* /index.html 200
-' > dist/_redirects

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,2 @@
+/ingest/static/*  https://us-assets.i.posthog.com/static/:splat  200!
+/ingest/*         https://us.i.posthog.com/:splat  200!


### PR DESCRIPTION
Apparently sveltekit's Netlify adapter automatically appends to the _redirects file at build time, so we have to put our custom redirects in the static folder so that they don't overwrite the sveltekit redirects.