### PR TITLE
fix: improvements to invite and thread toolbar

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -33,11 +33,8 @@ emoji-picker {
 
 /* Universal */
 
-.btn {
-  transition-property: all;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-  @apply hover:scale-[101%] active:scale-95;
+button {
+  @apply cursor-pointer;
 }
 
 /* TipTap Nodes */

--- a/src/lib/components/TimelineToolbar.svelte
+++ b/src/lib/components/TimelineToolbar.svelte
@@ -7,6 +7,7 @@
   import { Popover, Button } from "bits-ui";
   import Dialog from "$lib/components/Dialog.svelte";
   import { getContext, untrack } from "svelte";
+  import { toast } from "svelte-french-toast";
 
   let { createThread, threadTitleInput = $bindable() } = $props();
   let isThreading: { value: false } = getContext("isThreading");
@@ -100,33 +101,46 @@
     <Popover.Portal>
       <Popover.Content
         side="left"
-        sideOffset={8}
+        sideOffset={16}
         interactOutsideBehavior="ignore"
-        class="my-4 bg-base-300 rounded py-4 px-5"
+        class="my-4 bg-base-300 rounded py-4 px-5 max-w-[300px] w-full"
       >
-        <form onsubmit={createThread} class="flex flex-col gap-4">
-          <input
-            type="text"
-            bind:value={threadTitleInput}
-            class="dz-input"
-            placeholder="Thread Title"
-            required
-          />
-          <button type="submit" class="dz-btn dz-btn-primary">
-            Create Thread
-          </button>
-        </form>
+        <div class="flex flex-col gap-4">
+          <div class="flex justify-between items-center">
+            <h2 class="text-xl font-bold">Create Thread</h2>
+            <Popover.Close>
+              <Icon icon="lucide:x" class="text-2xl" />
+            </Popover.Close>
+          </div>
+          <p class="text-sm text-base-content">
+            Threads are a way to organize messages in a channel. Select as many
+            messages as you want and join them into a new thread.
+          </p>
+          <form onsubmit={createThread} class="flex flex-col gap-4">
+            <input
+              type="text"
+              bind:value={threadTitleInput}
+              class="dz-input"
+              placeholder="Thread Title"
+              required
+            />
+            <button type="submit" class="dz-btn dz-btn-primary">
+              Create Thread
+            </button>
+          </form>
+        </div>
       </Popover.Content>
     </Popover.Portal>
   </Popover.Root>
+
   <Button.Root
     title="Copy invite link"
-    class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150"
     onclick={() => {
       navigator.clipboard.writeText(`${page.url.href}`);
+      toast.success("Invite link copied to clipboard");
     }}
   >
-    <Icon icon="icon-park-outline:copy-link" class="text-2xl" />
+    <Icon icon="icon-park-outline:people-plus" class="text-2xl" />
   </Button.Root>
 
   {#if g.isAdmin}
@@ -141,7 +155,7 @@
           title={g.channel instanceof Channel
             ? "Channel Settings"
             : "Thread Settings"}
-          class="cursor-pointer hover:scale-105 active:scale-95 transition-all duration-150 m-auto flex"
+          class="m-auto flex"
         >
           <Icon icon="lucide:settings" class="text-2xl" />
         </Button.Root>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -64,7 +64,9 @@
 </svelte:head>
 
 {#if dev}
-  <RenderScan />
+  <!-- Displays rendering scanner for debugging.
+       Uncomment then recomment before committing. -->
+  <!-- <RenderScan /> -->
 {/if}
 
 <!-- Container -->


### PR DESCRIPTION
Unrelated tweaks:
- removed hover animation on some buttons
- cursor now changes to pointer by default on all buttons (we were doing this manually on each one before lol)

Shot 1:
- replaced invite button with new icon
- added explainer copy to `Create thread` popup
- added close button to popup

Shot 2:
- added success toast on invite button click - fixes: #173 

## Visuals
| Shot 1 | Shot 2 |
|--------|--------|
| ![Screenshot 2025-05-02 012749](https://github.com/user-attachments/assets/d579993d-e9bc-4237-a7a5-2df3ffdfb543) | ![Screenshot 2025-05-02 012757](https://github.com/user-attachments/assets/524d194d-1c15-437a-a2bb-3731ea076b36) |

