### PR TITLE
fix: improved theming to messages, mentions, emoji panel, and timeline view

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -26,7 +26,7 @@
 }
 
 emoji-picker {
-  --background: var(--color-violet-900);
+  --background: var(--color-neutral);
   --border-radius: 8px;
   --button-hover-background: --alpha(var(--color-white) / 10%);
 }

--- a/src/app.css
+++ b/src/app.css
@@ -27,8 +27,12 @@
 
 emoji-picker {
   --background: var(--color-neutral);
+  --border-color: var(--color-accent-content);
   --border-radius: 8px;
   --button-hover-background: --alpha(var(--color-white) / 10%);
+  --input-border-color: --alpha(var(--color-neutral-content) / 50%);
+  --outline-color: --alpha(var(--color-neutral-content) / 80%);
+  --outline-size: 1px;
 }
 
 /* Universal */

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -321,9 +321,9 @@
 
 <svelte:window onkeydown={onKeydown} onkeyup={onKeyup} />
 
-<li id={message.id} class={`flex flex-col ${isMobile && "max-w-screen"}`}>
+<div id={message.id} class={`flex flex-col ${isMobile && "max-w-screen"}`}>
   <div
-    class={`relative group w-full h-fit flex flex-col gap-4 px-2 ${!mergeWithPrevious && "pt-5"}  hover:bg-white/5 transition-all duration-75`}
+    class={`relative group w-full h-fit flex flex-col gap-2 px-2 py-2 hover:bg-white/5`}
   >
     {#if message instanceof Announcement}
       {@render announcementView(message)}
@@ -333,15 +333,13 @@
     {/if}
 
     {#if Object.keys(message.reactions.all()).length > 0}
-      <div class="flex gap-2 flex-wrap">
+      <div class="flex gap-2 flex-wrap pl-14">
         {#each Object.keys(message.reactions.all()) as reaction}
           {@render reactionToggle(reaction)}
         {/each}
         <Popover.Root bind:open={isEmojiRowPickerOpen}>
-          <Popover.Trigger
-            class="p-2 hover:bg-white/5 hover:scale-105 active:scale-95 transition-all duration-150 rounded cursor-pointer"
-          >
-            <Icon icon="lucide:smile-plus" color="white" />
+          <Popover.Trigger class="p-2 hover:bg-white/5 rounded cursor-pointer">
+            <Icon icon="lucide:smile-plus" class="text-primary" />
           </Popover.Trigger>
           <Popover.Content class="z-10">
             <emoji-picker bind:this={emojiRowPicker}></emoji-picker>
@@ -350,12 +348,12 @@
       </div>
     {/if}
   </div>
-</li>
+</div>
 
 {#snippet announcementView(announcement: Announcement)}
   {@const relatedMessage = relatedMessages.value[0]}
   {@render toolbar()}
-  <div class="flex flex-col gap-4">
+  <div class="flex flex-col gap-4 pl-14">
     {#if announcement.kind === "threadCreated"}
       <Button.Root
         onclick={() => {
@@ -427,16 +425,10 @@
           />
         </a>
       {:else}
-        <div
-          class="w-10 flex items-center justify-center relative group select-none pointer-events-none"
-        >
-          <AvatarImage
-            handle={authorProfile.handle}
-            className="opacity-0 pointer-events-none select-none"
-          />
+        <div class="w-11">
           {#if message.createdDate}
             <span
-              class="opacity-0 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-[8px] text-gray-300 transition-opacity duration-200 whitespace-nowrap group-hover:opacity-100"
+              class="opacity-0 text-[8px] text-gray-300 transition-opacity duration-200 whitespace-nowrap group-hover:opacity-100"
             >
               {format(message.createdDate, "pp")}
             </span>
@@ -511,7 +503,10 @@
           {/if}
 
           <div class="flex flex-col gap-1">
-            <span class="dz-prose select-text">
+            <!-- Using a fancy Tailwind trick to target all href elements inside of this parent -->
+            <span
+              class="dz-prose select-text [&_a]:text-primary [&_a]:hover:underline"
+            >
               {@html getContentHtml(JSON.parse(msg.bodyJson))}
             </span>
 
@@ -725,7 +720,7 @@
         onclick={() => toggleReaction(reaction)}
         class={`
       dz-btn
-      ${user.agent && reactions.has(user.agent.assertDid) ? "bg-accent text-accent-content" : "bg-secondary text-secondary-content"}
+      ${user.agent && reactions.has(user.agent.assertDid) ? "bg-secondary text-secondary-content" : "bg-secondary/30 hover:bg-secondary/50 text-base-content"}
     `}
         title={profilesThatReacted
           .map((x) => x.displayName || x.handle)
@@ -746,7 +741,7 @@
     {#if messageRepliedTo.value && profileRepliedTo}
       <Button.Root
         onclick={scrollToReply}
-        class="cursor-pointer flex gap-2 text-sm text-start w-full items-center text-secondary-content px-4 py-1 bg-secondary rounded-t"
+        class="cursor-pointer flex gap-2 text-sm text-start w-full items-center text-base-content px-4 py-1"
       >
         <div class="flex basis-1/2 md:basis-auto gap-2 items-center">
           <Icon icon="prime:reply" width="12px" height="12px" />
@@ -759,7 +754,7 @@
               <AvatarBeam name={profileRepliedTo.handle} />
             </Avatar.Fallback>
           </Avatar.Root>
-          <h5 class="text-secondary-content font-medium text-ellipsis">
+          <h5 class="text-base-content font-medium text-ellipsis">
             {profileRepliedTo.handle}
           </h5>
         </div>

--- a/src/lib/components/SuggestionSelect.svelte
+++ b/src/lib/components/SuggestionSelect.svelte
@@ -4,13 +4,13 @@
 
   type Option = Item & { category: string };
 
-  type Props = { 
+  type Props = {
     items: Option[];
-    callback: ({ id, label }: { id: string, label: string }) => void;
-  }
+    callback: ({ id, label }: { id: string; label: string }) => void;
+  };
 
   let activeIndex = $state(0);
-  
+
   let { items, callback }: Props = $props();
 
   let categories = $derived.by(() => {
@@ -19,24 +19,26 @@
     return [...name.values()];
   });
 
-  export function setItems(value: any[]) { items = value; }
+  export function setItems(value: any[]) {
+    items = value;
+  }
   export function onKeyDown(event: KeyboardEvent) {
-    if (event.repeat) { return false; }
+    if (event.repeat) {
+      return false;
+    }
     switch (event.key) {
       case "ArrowUp": {
-        if (activeIndex <= 0) { 
+        if (activeIndex <= 0) {
           activeIndex = items.length - 1;
-        }
-        else {
+        } else {
           activeIndex--;
         }
         return true;
       }
       case "ArrowDown": {
-        if (activeIndex >= items.length - 1) { 
+        if (activeIndex >= items.length - 1) {
           activeIndex = 0;
-        }
-        else {
+        } else {
           activeIndex++;
         }
         return true;
@@ -52,19 +54,22 @@
   }
 </script>
 
-<menu class="bg-violet-900 p-4 flex flex-col gap-3">
+<menu class="bg-neutral p-4 flex flex-col gap-3">
   {#each categories as category, c}
-    {@const prevCategoryLength = c === 0 ? 0 : items.filter((i) => i.category === categories[c-1]).length}
+    {@const prevCategoryLength =
+      c === 0
+        ? 0
+        : items.filter((i) => i.category === categories[c - 1]).length}
     <h5 class="uppercase text-gray-300">{category}</h5>
     {#each items.filter((i) => i.category === category) as { value, label, disabled }, i (i + value)}
       {@const actualIndex = i + prevCategoryLength}
-      <Button.Root 
+      <Button.Root
         {disabled}
         class={[
-          actualIndex === activeIndex && "!border-white", 
-          "border border-violet-800 px-3 py-2 flex gap-4 bg-violet-800 text-white rounded cursor-pointer"
+          actualIndex === activeIndex && "!border-neutral-content",
+          "border border-neutral-content/30 px-3 py-2 flex gap-4 bg-neutral text-white rounded cursor-pointer",
         ]}
-        onmouseover={() => activeIndex = actualIndex}
+        onmouseover={() => (activeIndex = actualIndex)}
         onclick={() => callback({ id: value, label })}
       >
         {label}

--- a/src/lib/components/TimelineView.svelte
+++ b/src/lib/components/TimelineView.svelte
@@ -287,7 +287,7 @@
                     <strong>{profile.handle}</strong>
                   {/await}
                 </h5>
-                <p class="text-gray-300 text-ellipsis italic">
+                <p class="text-primary-content text-ellipsis italic">
                   {@html getContentHtml(JSON.parse(replyingTo.bodyJson))}
                 </p>
               </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,3 @@
+// This just has to be here to make sure the tailwind plugin is loaded in vscode.
+// Insane, I know.
+// We can remove this in the future if we want to.


### PR DESCRIPTION
closes: #109

This one should be a nice little clean-up of several styles that were still hard-coded and didn't adapt with the theme. I've also made some subtle, but much needed changes to our message padding.

Each message is now given just a bit more space to breathe while still keeping messages grouped. The hover effects and padding have been adjusted as well. Everything should just feel less **claustrophobic** overall. Oh, and links are now colored correctly. 🎉 

> [!NOTE]
> I think the theming is great. But our themes for sure need a once-over to adjust them for accessibility. And to make sure they make sense. We could probably just choose 10 from the list that look great and remove the rest.

## Visuals
![mentions-theme-colors](https://github.com/user-attachments/assets/7b0fec11-e394-4a38-bffa-1643e3e8cda2)

![image](https://github.com/user-attachments/assets/a58eb910-46ea-4cc2-9be7-fb8bbac7ee02)

