### PR TITLE
fix: disallow sending blank message

### DIFF
--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -132,6 +132,15 @@
         // Update the message
         message.bodyJson = JSON.stringify(plainContent);
 
+        console.log("Saving edited message:", message.bodyJson);
+        // If message is empty, don't save it
+        if (
+          message.bodyJson === '{"type":"doc","content":[{"type":"paragraph"}]}'
+        ) {
+          toast.error("Message cannot be empty", { position: "bottom-end" });
+          return;
+        }
+
         // Add an updatedDate field to track edits
         // @ts-ignore - Adding custom property for edit tracking
         message.updatedDate = new Date();

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -132,7 +132,6 @@
         // Update the message
         message.bodyJson = JSON.stringify(plainContent);
 
-        console.log("Saving edited message:", message.bodyJson);
         let messageJSON = JSON.parse(message.bodyJson) as JSONContent;
 
         messageJSON.content = (messageJSON.content ?? []).map((block) => {
@@ -157,14 +156,12 @@
           return block;
         });
 
-        console.log("messageJSON", messageJSON);
 
         // If message is empty, don't save it
         if (
           messageJSON.content[0]?.content?.length === 0 ||
           !messageJSON.content[0]?.content
         ) {
-          toast.error("Message cannot be empty", { position: "bottom-end" });
           return;
         }
         message.bodyJson = JSON.stringify(messageJSON);

--- a/src/lib/components/TimelineView.svelte
+++ b/src/lib/components/TimelineView.svelte
@@ -146,6 +146,14 @@
       (authors) => user.agent && authors.push(user.agent.assertDid),
     );
     message.bodyJson = JSON.stringify(messageInput);
+
+    console.log(message.bodyJson);
+    // If message is empty, don't save it
+    if (Object.keys(JSON.parse(message.bodyJson)).length === 0) {
+      toast.error("Message cannot be empty", { position: "bottom-end" });
+      return;
+    }
+
     message.createdDate = new Date();
     message.commit();
     if (replyingTo) message.replyTo = replyingTo;

--- a/src/lib/components/TimelineView.svelte
+++ b/src/lib/components/TimelineView.svelte
@@ -170,14 +170,13 @@
       return block;
     });
 
-    console.log("messageJSON", messageJSON);
 
     // If message is empty, don't save it
     if (
       messageJSON.content[0]?.content?.length === 0 ||
       !messageJSON.content[0]?.content
     ) {
-      toast.error("Message cannot be empty", { position: "bottom-end" });
+      toast.error("Message cannot be empty");
       return;
     }
     message.bodyJson = JSON.stringify(messageJSON);


### PR DESCRIPTION
This commit contains fixes for #227 

Both while sending the new message while and also while editing the already sent message following cases are handles
- When message is empty
- When message contains empty spaces
- Removing spaces When message contains hardbreaks or spaces before any text

When message will be empty it will not send message and will generate the error that "Message cannot be empty".

Please let me know if I have missed anything or need to consider any other cases. 

fixes: #227 