### PR TITLE
fix: fix infinite loading spinner for new users.

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -463,7 +463,7 @@ export class Roomy extends EntityWrapper {
    * joined spaces, preferences, etc.
    * */
   static async init(peer: Peer, catalogId: IntoEntityId): Promise<Roomy> {
-    const catalog = await peer.open(intoEntityId(catalogId));
+    const catalog = await peer.open(intoEntityId(catalogId), { createAfterTimeout: 4000 });
     return new Roomy(peer, catalog);
   }
 


### PR DESCRIPTION
Adds a change that was lost in a rebase and should have come with the recent sync protocol update.

This makes sure that if the user's catalog doesn't exist yet it will be created automatically after 4 seconds of trying to load it.

Thankfully a user chatted me on Bluesky and mentioned that it just kept loading forever. Glad we caught that before the conference. :sweat_smile: 