### PR TITLE
fix: add a hack to prevent lost entities from loading infinitely.

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -66,6 +66,11 @@ export class HasPeer {
 
   /** @group Advanced */
   constructor(peer: Peer) {
+    // Temporary hack to add a createAfterTimeout to every open call.
+    const origOpen = peer.open.bind(peer);
+    peer.open = (id, opts) => {
+      return origOpen(id, { ...{ createAfterTimeout: 5000 }, ...opts});
+    }
     this.peer = peer;
   }
 


### PR DESCRIPTION
Not sure how it happened but some entities ended up with their IDs referenced, but their data not pushed to the syncserver. when you try to load these, if you don't have the data locally, it will just load forever. This adds a hack that will just create an empty entity with the ID after a 5 second timeout whenever this happens.

Not a good solution, but we have changes we'll need to make soon around this anyway, so it should smooth over most of the issues temporarily.