### PR TITLE
fix: fix stack size limit exceeded exceptions.

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -66,10 +66,13 @@ export class HasPeer {
 
   /** @group Advanced */
   constructor(peer: Peer) {
-    // Temporary hack to add a createAfterTimeout to every open call.
-    const origOpen = peer.open.bind(peer);
-    peer.open = (id, opts) => {
-      return origOpen(id, { ...{ createAfterTimeout: 5000 }, ...opts});
+    if (!(peer.open as any).hacked) {
+      // Temporary hack to add a createAfterTimeout to every open call.
+      const origOpen = peer.open.bind(peer);
+      peer.open = (id, opts) => {
+        return origOpen(id, { ...{ createAfterTimeout: 5000 }, ...opts});
+      }
+      (peer.open as any).hacked = true;
     }
     this.peer = peer;
   }


### PR DESCRIPTION
There was an issue where our hack for injecting function argument defaults into `peer.open()` was being applied recursively or something.

This makes sure it only hacks if it hasn't already been hacked.