### PR TITLE
fix reply-click focus

### DIFF
--- a/packages/app/src/lib/components/ChatInput.svelte
+++ b/packages/app/src/lib/components/ChatInput.svelte
@@ -1,3 +1,10 @@
+<script module>
+  let editor: Editor;
+  export function setInputFocus() {
+    if (!editor) return;
+    editor.commands.focus();
+  }
+</script>
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import { Editor } from "@tiptap/core";
@@ -65,6 +72,7 @@
         content = ctx.editor.getHTML();
       },
     });
+    editor = tiptap
     if (setFocus) {
       // focus at the end of the content
       tiptap?.commands.focus();

--- a/packages/app/src/lib/components/ChatMessage.svelte
+++ b/packages/app/src/lib/components/ChatMessage.svelte
@@ -29,6 +29,7 @@
   import toast from "svelte-french-toast";
   import { addMessage } from "$lib/search.svelte";
   import ImageUrlEmbed from "./Message/embeds/ImageUrlEmbed.svelte";
+  import { setInputFocus } from "./ChatInput.svelte";
 
   const me = new AccountCoState(RoomyAccount, {
     resolve: {
@@ -153,6 +154,7 @@
 
   function setReplyTo() {
     replyTo.id = message.current?.id ?? "";
+    setInputFocus();
   }
 
   function convertReactionsToEmojis(


### PR DESCRIPTION
currently we lose input focus when we hit reply button, this will refocus and also gives us a general function to call tiptap focus [and other tiptap related funcs in the future maybe]