### PR TITLE
refactor: unify entity IDs under a SCALE enum so that we don't have to maintain ID maps.

### DIFF
--- a/packages/app/src/lib/components/content/thread/ChatArea.svelte
+++ b/packages/app/src/lib/components/content/thread/ChatArea.svelte
@@ -15,7 +15,7 @@
   import IconTablerArrowDown from "~icons/tabler/arrow-down";
   import { LiveQuery } from "$lib/liveQuery.svelte";
   import { sql } from "$lib/utils/sqlTemplate";
-  import { Ulid } from "$lib/workers/encoding";
+  import { id } from "$lib/workers/encoding";
 
   let {
     threading,
@@ -38,24 +38,25 @@
   let query = new LiveQuery<Message>(
     () => sql`
       select
-        format_ulid(c.entity) as id,
-        cast(data as text) as content,
+        id(c.entity) as id,
+        cast(c.data as text) as content,
         u.did as authorDid,
         i.name as authorName,
         i.avatar as authorAvatar,
         o.author as masqueradeAuthor,
         o.timestamp as masqueradeTimestamp
       from entities e
-        join comp_content c on c.entity = e.ulid
-        join edges author_edge on author_edge.head = e.ulid and author_edge.label = 'author'
-        join comp_user u on u.entity = author_edge.tail
+        join comp_content c on c.entity = e.id
+        join edges author_edge on author_edge.head = e.id and author_edge.label = 'author'
+        join comp_user u on u.did = author_edge.tail
         join comp_info i on i.entity = author_edge.tail
-        left join comp_override_meta o on o.entity = e.ulid
+        left join comp_override_meta o on o.entity = e.id
       where
-        e.parent = ${page.params.object && Ulid.enc(page.params.object)}
+        e.parent = ${page.params.object && id(page.params.object)}
       order by c.entity
     `,
   );
+  $inspect({ messages: query.result });
 
   let showLastN = $state(50);
   let isAtBottom = $state(true);

--- a/packages/app/src/lib/workers/materializer.ts
+++ b/packages/app/src/lib/workers/materializer.ts
@@ -4,15 +4,9 @@ import type {
   MaterializerConfig,
 } from "./backendWorker";
 import { _void, type CodecType } from "scale-ts";
-import {
-  eventCodec,
-  eventVariantCodec,
-  GroupMember,
-  Hash,
-  Ulid,
-} from "./encoding";
+import { eventCodec, eventVariantCodec, GroupMember, id } from "./encoding";
 import schemaSql from "./db/schema.sql?raw";
-import { decodeTime, ulid } from "ulidx";
+import { decodeTime } from "ulidx";
 import { sql } from "$lib/utils/sqlTemplate";
 import type { SqliteWorkerInterface } from "./types";
 import type { Agent } from "@atproto/api";
@@ -40,25 +34,16 @@ export async function materializer(
   streamId: string,
   events: StreamEvent[],
 ): Promise<void> {
-  console.time("convert");
-  const batch: SqlStatement[][] = [];
+  const batch: SqlStatement[] = [];
 
   // reset ensured flags for each new batch
-  ensuredProfiles = new Map();
+  ensuredProfiles = new Set();
 
+  console.time("convert-events-to-sql");
   for (const incoming of events) {
     try {
       // Decode the event payload
       const event = eventCodec.dec(incoming.payload);
-
-      console.log(
-        "Materialising event #",
-        incoming.idx,
-        "of type",
-        event.variant.kind,
-        "in stream",
-        streamId,
-      );
 
       // Get the SQL statements to be executed for this event
       const statements = await materializers[event.variant.kind]({
@@ -71,34 +56,23 @@ export async function materializer(
         data: event.variant.data,
       } as never);
 
-      console.log("materialisations mapped");
-
       statements.push(sql`
         update events set applied = 1 
-        where stream_hash_id = ${Hash.enc(streamId)} 
+        where stream_id = ${id(streamId)} 
           and
         idx = ${incoming.idx} `);
 
-      batch.push(statements);
-
-      // // Add a savepoint to the list
-      // savepoints.push({ name: "event", items: statements });
+      batch.push(...statements);
     } catch (e) {
       console.error(e);
     }
   }
-  console.timeEnd("convert");
-
-  console.log("Running batch of materialisations for stream", streamId);
+  console.timeEnd("convert-events-to-sql");
 
   // Execute all of the statements in a transaction
-  console.time("runSql");
-  await sqliteWorker.runSavepoint({ name: "batch", items: batch.flat() });
-  console.log(
-    "Batch of materialisations run successfully for stream",
-    streamId,
-  );
-  console.timeEnd("runSql");
+  console.time("run-events-sql-transaction");
+  await sqliteWorker.runSavepoint({ name: "batch", items: batch });
+  console.timeEnd("run-events-sql-transaction");
 }
 
 type Event = CodecType<typeof eventCodec>;
@@ -122,30 +96,20 @@ const materializers: {
   }) => Promise<SqlStatement[]>;
 } = {
   // Space
-  "space.roomy.space.join.0": async ({ streamId, data, leafClient }) => {
-    console.log("getting stamp for spaceId", data.spaceId);
-    const { stamp } = await leafClient.streamInfo(data.spaceId);
-    console.log("space streaminfo stamp", stamp);
+  "space.roomy.space.join.0": async ({ streamId, data }) => {
     return [
-      ensureEntity(streamId, stamp),
+      ensureEntity(streamId, data.spaceId),
       sql`
-      insert into comp_space (entity, leaf_space_hash_id, personal_stream_hash_id)
-      values (
-        ${Ulid.enc(stamp)},
-        ${Hash.enc(data.spaceId)},
-        ${Hash.enc(streamId)}
-      )
-      on conflict do update set hidden = 0
-    `,
+        insert into comp_space (entity)
+        values (${id(data.spaceId)})
+        on conflict do update set hidden = 0
+      `,
     ];
   },
-  "space.roomy.space.leave.0": async ({ streamId, data }) => [
+  "space.roomy.space.leave.0": async ({ data }) => [
     sql`
       update comp_space set hidden = 1
-      where
-        leaf_space_hash_id = ${Hash.enc(data.spaceId)}
-          and
-        personal_stream_hash_id = ${Hash.enc(streamId)}
+      where entity = ${id(data.spaceId)}
     `,
   ],
 
@@ -171,8 +135,8 @@ const materializers: {
       sql`
       insert or replace into edges (head, tail, label, payload)
       values (
-        (select entity from comp_space where leaf_space_hash_id = ${Hash.enc(streamId)}),
-        (select entity from comp_user where did = ${data.adminId}),
+        ${id(streamId)},
+        ${id(data.adminId)},
         'member',
         ${edgePayload({
           can: "admin",
@@ -183,19 +147,18 @@ const materializers: {
   },
   "space.roomy.admin.remove.0": async ({ streamId, data }) => [
     sql`
-      update space_admins (payload)
-      values (${JSON.stringify({ can: "post" })})
+      update edges set payload = (${JSON.stringify({ can: "post" })})
       where 
-        head = (select entity from comp_space where leaf_space_hash_id = ${Hash.enc(streamId)})
+        head = ${id(streamId)}
           and
-        tail = (select entity from comp_user where did = ${data.adminId})
+        tail = ${id(data.adminId)}
           and
         label = 'member'
     `,
   ],
 
   // Info
-  "space.roomy.info.0": async ({ streamId, event, data, sqliteWorker }) => {
+  "space.roomy.info.0": async ({ streamId, event, data }) => {
     const updates = [
       { key: "name", ...data.name },
       { key: "avatar", ...data.avatar },
@@ -203,38 +166,20 @@ const materializers: {
     ];
     const setUpdates = updates.filter((x) => x.tag == "set");
 
-    const check = await sqliteWorker.runQuery(sql`
-      select format_ulid(entity) from comp_space where leaf_space_hash_id = ${Hash.enc(streamId)}`);
-    console.log("check", check, "streamId", streamId);
-    console.log("setUpdates", setUpdates);
+    const entityId = event.parent ? event.parent : streamId;
 
-    if (!event.parent) {
-      return [
-        ensureEntity(streamId, event.ulid),
-        {
-          sql: `insert into comp_info (entity, ${setUpdates.map((x) => `${x.key}`).join(", ")})
-            VALUES ((select entity from comp_space where leaf_space_hash_id = :stream_id), ${setUpdates.map((x) => `:${x.key}`)}) on conflict do update
-            set ${[...setUpdates].map((x) => `${x.key} = :${x.key}`)}`,
-          params: Object.fromEntries([
-            [":stream_id", Hash.enc(streamId)],
-            ...setUpdates.map((x) => [":" + x.key, x.value]),
-          ]),
-        },
-      ];
-    } else {
-      return [
-        ensureEntity(streamId, event.ulid, event.parent),
-        {
-          sql: `insert into comp_info (entity, ${setUpdates.map((x) => `${x.key}`).join(", ")})
-            VALUES (:ulid, ${setUpdates.map((x) => `:${x.key}`)}) on conflict do update
-            set ${[...setUpdates].map((x) => `${x.key} = :${x.key}`)}`,
-          params: Object.fromEntries([
-            [":ulid", Ulid.enc(event.parent)],
-            ...setUpdates.map((x) => [":" + x.key, x.value]),
-          ]),
-        },
-      ];
-    }
+    return [
+      ensureEntity(streamId, event.ulid),
+      {
+        sql: `insert into comp_info (entity, ${setUpdates.map((x) => `${x.key}`).join(", ")})
+            VALUES (:entity, ${setUpdates.map((x) => `:${x.key}`)})
+            on conflict do update set ${[...setUpdates].map((x) => `${x.key} = :${x.key}`)}`,
+        params: Object.fromEntries([
+          [":entity", id(entityId)],
+          ...setUpdates.map((x) => [":" + x.key, x.value]),
+        ]),
+      },
+    ];
   },
 
   // Room
@@ -243,8 +188,8 @@ const materializers: {
     sql`
       insert into comp_room (entity, parent)
       values (
-        ${Ulid.enc(event.ulid)},
-        ${event.parent ? Ulid.enc(event.parent) : null}
+        ${id(event.ulid)},
+        ${event.parent ? id(event.parent) : null}
       ) on conflict do update set parent = excluded.parent
     `,
   ],
@@ -257,7 +202,7 @@ const materializers: {
       sql`
         update comp_room
         set deleted = 1
-        where id = ${Ulid.enc(event.parent)}
+        where id = ${id(event.parent)}
       `,
     ];
   },
@@ -331,15 +276,15 @@ const materializers: {
       sql`
         insert into edges (head, tail, label)
         values (
-          ${Ulid.enc(event.ulid)},
-          (select entity from comp_user where did = ${user}),
+          ${id(event.ulid)},
+          ${id(user)},
           'author'
         )
       `,
       sql`
         insert or replace into comp_content (entity, mime_type, data)
         values (
-          ${Ulid.enc(event.ulid)},
+          ${id(event.ulid)},
           ${data.content.mimeType},
           ${data.content.content}
         )`,
@@ -349,8 +294,8 @@ const materializers: {
       statements.push(sql`
         insert into edges (head, tail, label)
         values (
-          ${Ulid.enc(event.ulid)},
-          ${Ulid.enc(data.replyTo)},
+          ${id(event.ulid)},
+          ${id(data.replyTo)},
           'reply'
         )
       `);
@@ -365,7 +310,7 @@ const materializers: {
       set 
         mime_type = ${data.content.mimeType},
         data = ${data.content.content}
-      where entity = ${Ulid.enc(event.ulid)}
+      where entity = ${id(event.ulid)}
     `,
   ],
   "space.roomy.message.overrideMeta.0": async ({ event, data }) => {
@@ -377,8 +322,8 @@ const materializers: {
       sql`
         insert or replace into comp_override_meta (entity, author, timestamp)
         values (
-          ${Ulid.enc(event.parent)},
-          ${data.author},
+          ${id(event.parent)},
+          ${id(data.author)},
           ${Number(data.timestamp)}
         )`,
     ];
@@ -388,27 +333,20 @@ const materializers: {
       console.warn("Missing target for message meta override.");
       return [];
     }
-    return [sql`delete from entities where ulid = ${Ulid.enc(event.parent)}`];
+    return [sql`delete from entities where id = ${id(event.parent)}`];
   },
 
   // Reaction
-  "space.roomy.reaction.create.0": async ({ streamId, event, data }) => [
+  "space.roomy.reaction.create.0": async ({ streamId, event }) => [
     ensureEntity(streamId, event.ulid, event.parent),
-    sql`
-      insert into comp_reaction (entity, reaction_to, reaction)
-      values (
-        ${Ulid.enc(event.ulid)},
-        ${Ulid.enc(data.reaction_to)},
-        ${data.reaction}
-      )
-    `,
+    // TODO: insert edge for reaction
   ],
   "space.roomy.reaction.delete.0": async ({ event }) => {
     if (!event.parent) {
       console.warn("Delete reaction missing parent");
       return [];
     }
-    return [sql`delete from entities where ulid = ${Ulid.enc(event.parent)}`];
+    return [sql`delete from entities where id = ${id(event.parent)}`];
   },
 
   // Media
@@ -417,7 +355,7 @@ const materializers: {
     sql`
       insert into comp_media (entity, uri)
       values (
-        ${Ulid.enc(event.ulid)},
+        ${id(event.ulid)},
         ${data.uri}
       )
     `,
@@ -428,7 +366,7 @@ const materializers: {
       console.warn("Missing target for media delete.");
       return [];
     }
-    return [sql`delete from entities where ulid = ${Ulid.enc(event.parent)}`];
+    return [sql`delete from entities where id = ${id(event.parent)}`];
   },
 
   // Channels
@@ -439,7 +377,7 @@ const materializers: {
     }
     return [
       sql`
-      update comp_room set label = 'channel' where entity = ${Ulid.enc(event.parent)}
+      update comp_room set label = 'channel' where entity = ${id(event.parent)}
       `,
     ];
   },
@@ -449,7 +387,7 @@ const materializers: {
       return [];
     }
     return [
-      sql`update comp_room set label = null where entity = ${Ulid.enc(event.parent)} and label = 'channel'`,
+      sql`update comp_room set label = null where entity = ${id(event.parent)} and label = 'channel'`,
     ];
   },
 
@@ -460,7 +398,7 @@ const materializers: {
       return [];
     }
     return [
-      sql`update comp_room set label = 'category' where entity = ${Ulid.enc(event.parent)}`,
+      sql`update comp_room set label = 'category' where entity = ${id(event.parent)}`,
     ];
   },
   "space.roomy.category.unmark.0": async ({ event }) => {
@@ -469,7 +407,7 @@ const materializers: {
       return [];
     }
     return [
-      sql`update comp_room set label = null where entity = ${Ulid.enc(event.parent)} and label = 'category'`,
+      sql`update comp_room set label = null where entity = ${id(event.parent)} and label = 'category'`,
     ];
   },
 };
@@ -478,22 +416,26 @@ const materializers: {
 
 function ensureEntity(
   streamId: string,
-  ulid: string,
+  entityId: string,
   parent?: string,
 ): SqlStatement {
-  const unixTimeMs = decodeTime(ulid);
+  let unixTimeMs = Date.now();
+
+  // If the entity ID is a ulid, decode the time and use that as the created time.
+  try {
+    unixTimeMs = decodeTime(entityId);
+  } catch (_) {}
+
   const statement = sql`
-    insert into entities (ulid, stream_hash_id, parent, created_at)
+    insert into entities (id, stream_id, parent, created_at)
     values (
-      ${Ulid.enc(ulid)},
-      ${Hash.enc(streamId)},
-      ${parent ? Ulid.enc(parent) : undefined},
+      ${id(entityId)},
+      ${id(streamId)},
+      ${parent ? id(parent) : undefined},
       ${unixTimeMs}
     )
-    on conflict(ulid) do nothing
+    on conflict(id) do nothing
   `;
-  console.log("ensureEntity ulid", ulid, Ulid.enc(ulid));
-  console.log("ensureEntity statement", statement);
   return statement;
 }
 
@@ -503,10 +445,10 @@ function ensureEntity(
  * inserting it immediately and breaking transaction atomicity, this is just a set
  * of flags to indicate that the profile doesn't need to be re-fetched.
  */
-let ensuredProfiles = new Map();
+let ensuredProfiles = new Set();
 
 async function ensureProfile(
-  sqliteWorker: SqliteWorkerInterface,
+  _sqliteWorker: SqliteWorkerInterface,
   agent: Agent,
   member: CodecType<typeof GroupMember>,
   streamId: string,
@@ -524,40 +466,31 @@ async function ensureProfile(
 
       if (!profile.success) return [];
 
-      const existingEntity = await sqliteWorker.runQuery(sql`
-        select format_ulid(entity) as ulid from comp_user where did = ${did}
-      `);
-      let existingUlid = existingEntity.rows?.[0]?.ulid as string | undefined;
-      let userUlid = existingUlid || ulid();
-
-      ensuredProfiles.set(did, userUlid);
-
-      if (existingUlid) return [];
+      if (ensuredProfiles.has(did)) return [];
 
       return [
         sql`
-          insert into entities (ulid, stream_hash_id)
-          values (${Ulid.enc(userUlid)}, ${Hash.enc(streamId)})
-          on conflict(ulid) do nothing
-          `,
+          insert into entities (id, stream_id)
+          values (${id(did)}, ${id(streamId)})
+          on conflict(id) do nothing
+        `,
         sql`
-        insert into comp_user (entity, did, handle)
-        values (
-           ${Ulid.enc(userUlid)},
-           ${did},
-           ${profile.data.handle}
-        )
-        on conflict(entity) do nothing
-      `,
+          insert into comp_user (did, handle)
+          values (
+            ${id(did)},
+            ${profile.data.handle}
+          )
+          on conflict(did) do nothing
+        `,
         sql`
           insert into comp_info (entity, name, avatar)
           values (
-            ${Ulid.enc(userUlid)},
+            ${id(did)},
             ${profile.data.displayName},
             ${profile.data.avatar}
           )
           on conflict(entity) do nothing
-          `,
+        `,
       ];
     } else {
       return [];

--- a/packages/app/src/lib/workers/sqliteWorker.ts
+++ b/packages/app/src/lib/workers/sqliteWorker.ts
@@ -80,7 +80,7 @@ async function runSavepoint(savepoint: Savepoint, depth = 0) {
         }
       }
     } catch (e) {
-      console.error("Error executing savepoint", e);
+      console.error(`Error executing savepoint: ${savepoint.name}`, e);
       await executeQuery({ sql: `rollback to ${savepoint.name}` });
     }
     await executeQuery({ sql: `release ${savepoint.name}` });

--- a/packages/app/src/routes/(app)/[space=hash]/new/+page.svelte
+++ b/packages/app/src/routes/(app)/[space=hash]/new/+page.svelte
@@ -6,7 +6,7 @@
   import { navigate } from "$lib/utils.svelte";
   import { sql } from "$lib/utils/sqlTemplate";
   import { backend } from "$lib/workers";
-  import { Hash } from "$lib/workers/encoding";
+  import { id } from "$lib/workers/encoding";
   import { Button, Input, ScrollArea, Select } from "@fuxui/base";
   import { monotonicFactory } from "ulidx";
 
@@ -18,12 +18,12 @@
 
   let categoriesQuery = new LiveQuery<{ name: string; id: string }>(
     () => sql`
-      select i.name, format_ulid(e.ulid) as id
+      select i.name, id(e.id) as id
       from entities e
-        inner join comp_room r on e.ulid = r.entity
-        inner join comp_info i on e.ulid = i.entity
+        inner join comp_room r on e.id = r.entity
+        inner join comp_info i on e.id = i.entity
       where
-        e.stream_hash_id = ${current.space?.id && Hash.enc(current.space.id)}
+        e.stream_id = ${current.space?.id && id(current.space.id)}
           and
         r.label = 'category' 
     `,
@@ -74,6 +74,8 @@
           data: undefined,
         },
       });
+
+      navigate({ space: current.space.id, object: roomId });
     } else if (type == "Category") {
       // Mark the room as a category
       await backend.sendEvent(current.space.id, {
@@ -84,9 +86,9 @@
           data: undefined,
         },
       });
-    }
 
-    navigate({ space: current.space.id, object: roomId });
+      navigate({ space: current.space.id });
+    }
   }
 </script>
 


### PR DESCRIPTION
This commit migrates entities to use IDs that, instead of always being ULIDs, are an enum that can be either:

- unknown: any string ID we don't understand
- ulid: a ULID
- hash: a 32 byte hash formatted in hex
- did: a DID, such as for a user account

This allows us to store everything as an entity using it's canonical ID as it's entity ID, greatly simplifying things throughout the codebase.

It also uses simplified functions in JS for encoding IDs `id()` and a SQL user-defined-function with the same name to format the IDs back to their string form during querying.