### PR TITLE
ci: make sure disabled CI job doesn't send email for not running.

### DIFF
--- a/.github/workflows/discord-bot.yaml
+++ b/.github/workflows/discord-bot.yaml
@@ -1,11 +1,10 @@
 name: Build & Publish Discord Bridge Docker Image
 on:
-  # This isn't working anymore so disable the build, but keep the file for reference.
-  # push:
-  #   branches:
-  #     - main
-  #   tags:
-  #     - "v*"
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
 permissions:
   packages: write
 
@@ -14,6 +13,8 @@ env:
 
 jobs:
   build-and-publish:
+    # This isn't working anymore so disable the build, but keep the file for reference.
+    if: 'false'
     name: Build and Publish Docker Image
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
GitHub is sending an email on every merge to main that the discord bot CI didn't run. This switches it to have triggers, but set a condition so that the job doesn't run, which avoids the email.