### PR TITLE
feat: provide mechanism for updating stream schema version and avoiding the need to manually reset the local cache.

### DIFF
--- a/packages/app/src/lib/config.ts
+++ b/packages/app/src/lib/config.ts
@@ -1,4 +1,5 @@
 export const CONFIG = {
   leafUrl: import.meta.env.VITE_LEAF_URL || "leaf-dev.muni.town",
   streamNsid: import.meta.env.VITE_STREAM_NSID || "space.roomy.stream.dev",
+  streamSchemaVersion: "1",
 };

--- a/packages/app/src/lib/lexicons.ts
+++ b/packages/app/src/lib/lexicons.ts
@@ -10,10 +10,6 @@ export const lexicons: LexiconDoc[] = [
         record: {
           type: "object",
           properties: {
-            version: {
-              type: "integer",
-              const: 1,
-            },
             id: {
               type: "string",
             },
@@ -31,10 +27,6 @@ export const lexicons: LexiconDoc[] = [
         record: {
           type: "object",
           properties: {
-            version: {
-              type: "integer",
-              const: 1,
-            },
             id: {
               type: "string",
             },

--- a/packages/app/src/lib/workers/encoding.ts
+++ b/packages/app/src/lib/workers/encoding.ts
@@ -320,3 +320,10 @@ export const eventCodec = Struct({
   /** The event variant. */
   variant: eventVariantCodec,
 });
+
+export const streamParamsCodec = Struct({
+  /** The type of stream as an NSID. */
+  streamType: str,
+  /** The stream schema version from $lib/config.ts CONFIG.streamSchemaVersion. */
+  schemaVersion: str,
+});

--- a/packages/app/src/routes/(app)/new/+page.svelte
+++ b/packages/app/src/routes/(app)/new/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import SpaceAvatar from "$lib/components/spaces/SpaceAvatar.svelte";
+  import { CONFIG } from "$lib/config";
   import { LEAF_MODULE_PUBLIC_READ_WRITE } from "$lib/moduleUrls";
   import { navigate } from "$lib/utils.svelte";
   import { backend, backendStatus } from "$lib/workers";
+  import { streamParamsCodec } from "$lib/workers/encoding";
   import { Button, Checkbox, Input, Label, Textarea, toast } from "@fuxui/base";
   import { ulid } from "ulidx";
 
@@ -50,6 +52,10 @@
         ulid(),
         LEAF_MODULE_PUBLIC_READ_WRITE.id,
         LEAF_MODULE_PUBLIC_READ_WRITE.url,
+        streamParamsCodec.enc({
+          streamType: "space.roomy.stream.space",
+          schemaVersion: CONFIG.streamSchemaVersion,
+        }).buffer as ArrayBuffer,
       );
 
       // Join the space


### PR DESCRIPTION
Adds a new streamSchemaVersion config that, when we need to change it, will automatically clear the local cache and load a new personal stream with that version number, so that the old stream info is preserved but the new version of the app has a clean slate instead of breaking by trying to read the old streams.

Also adds parameters to the stream specifying the kind of stream and the schema version, so that it's possible for the app to detect what version and kind of stream something is just from the stream metadata.