### PR TITLE
fix: disable the service worker if one is installed.

### DIFF
--- a/packages/app/src/hooks.client.ts
+++ b/packages/app/src/hooks.client.ts
@@ -5,6 +5,17 @@ import posthog from "posthog-js";
 if (dev && window.location.hostname == "localhost")
   window.location.hostname = "127.0.0.1";
 
+// For now, unregister the service worker, in case it might be causing problems.
+window.navigator.serviceWorker.getRegistrations().then(registrations => {
+  let hadRegistration = false;
+  for (const registration of registrations) {
+    hadRegistration = true;
+    registration.unregister()
+  }
+  // Reload the page just to make sure things are totally reset.
+  if (hadRegistration) window.location.reload();
+})
+
 export const handleError: HandleClientError = async ({
   error,
   event,


### PR DESCRIPTION
Previous versions of Roomy had a service worker
in order to support offline use, but offline support was never actually implemented.

This unregisters the service worker if it happens to be installed from previous versions of Roomy so that it doesn't cause any problems, just in case.