### PR TITLE
fix: fix error parsing "undefined" when trying to login.

### DIFF
--- a/packages/app/src/lib/components/user/LoginForm.svelte
+++ b/packages/app/src/lib/components/user/LoginForm.svelte
@@ -38,7 +38,7 @@
     $state(undefined);
 
   onMount(() => {
-    lastLogin = JSON.parse(localStorage.getItem("last-login") || "undefined");
+    lastLogin = JSON.parse(localStorage.getItem("last-login") || "null");
   });
 </script>
 


### PR DESCRIPTION
`undefined` is a JS thing, but I was passing it to a JSON parser, which only recognizes `null`.