### PR TITLE
feat: improve performance of message query by indexing edges.

### DIFF
--- a/packages/app/src/lib/workers/db/schema.sql
+++ b/packages/app/src/lib/workers/db/schema.sql
@@ -31,6 +31,9 @@ CREATE TABLE IF NOT EXISTS edges (
     FOREIGN KEY (head) REFERENCES entities(id) ON DELETE CASCADE,
     FOREIGN KEY (tail) REFERENCES entities(id) ON DELETE CASCADE
 ) STRICT;
+create index if not exists idx_edges_label on edges(label);
+create index if not exists idx_edges_label_head on edges(label, head);
+create index if not exists idx_edges_label_tail on edges(label, tail);
 
 create table if not exists comp_space (
   entity blob primary key references entities(id) on delete cascade,


### PR DESCRIPTION
@meri-leeworthy thought you might be interested in this.

Since adding the reactions, the query to get a large list of chat messages was going a lot slower, since it has to lookup the reactions for every message and the display name of every user that reacted.

So I printed out the query plan to see if there was anything obvious:

**Query plan before this PR:**
<img width="836" height="353" alt="image" src="https://github.com/user-attachments/assets/9b2d8c77-6f71-46f6-9415-11503ef442bd" />

Those SCAN operations are bad because it means it's looping over every record in the table, usually because there's no index.

I know we had an index on edges at one point so it just got lost in the refactor chaos.

What was interesting, though, is that adding indexes individually on head, label, and tail, only helped a little bit. What really helped was adding an index on `edges(label, head)` and `edges(label, tail)`.

Indexing on both head/tail and label at the same time, which is almost always what we will need to do, makes the index fit our query much better and run a lot faster.

Super easy, and pretty fun.

**Query plan after this PR:**
<img width="843" height="327" alt="image" src="https://github.com/user-attachments/assets/92e40bd5-cd08-4bc3-a590-152d318ccb12" />
