### PR TITLE
fix: fix ULID encoding/decoding and fix unit tests that verify it's working.

### DIFF
--- a/packages/app/src/lib/workers/encoding.test.ts
+++ b/packages/app/src/lib/workers/encoding.test.ts
@@ -1,7 +1,7 @@
-import { expect, test } from "vitest";
+import { assert, expect, test } from "vitest";
 
 import { Hash, id, IdCodec, Ulid } from "./encoding";
-import { ulid } from "ulidx";
+import { monotonicFactory, ulid } from "ulidx";
 
 const exampleHash =
   "fbef79b1f9e2facd237e0b131b96c17a47b2e9ea9c9f7e0632c0816b905e0e9d";
@@ -11,17 +11,29 @@ test("ulid encoding round trip", () => {
   // Round trip 15 ulids
   for (let i = 0; i < 15; i++) {
     const u = ulid();
-    expect(Ulid.dec(Ulid.enc(u)), u);
+    const u2 = Ulid.dec(Ulid.enc(u));
+    assert(u2 == u, `${u} != ${u2}`);
+  }
+});
+
+test("ulid monotonic factory encoding round trip", () => {
+  const ulid = monotonicFactory();
+  // Round trip 15 ulids
+  for (let i = 0; i < 15; i++) {
+    const u = ulid();
+    const u2 = Ulid.dec(Ulid.enc(u));
+
+    assert(u == u2, `${u} != ${u2}`);
   }
 });
 
 test("hash encoding round trip", () => {
-  expect(Hash.dec(Hash.enc(exampleHash)), exampleHash);
+  assert(Hash.dec(Hash.enc(exampleHash)) == exampleHash);
 });
 
 test("ID encoding round trip", () => {
-  expect(IdCodec.dec(id(exampleDiscordDid)), exampleDiscordDid);
-  expect(IdCodec.dec(id(exampleHash)), exampleHash);
+  assert(IdCodec.dec(id(exampleDiscordDid)) == exampleDiscordDid);
+  assert(IdCodec.dec(id(exampleHash)) == exampleHash);
   const u = ulid();
-  expect(IdCodec.dec(id(u)), u);
+  assert(IdCodec.dec(id(u)) == u);
 });


### PR DESCRIPTION
I had incorrectly used the expect() function in our unit tests so they were not actually testing and our ULID encoding/decoding was actually broken. This fixes both issues.