### PR TITLE
perf: greatly improve backfill performance.

### DIFF
--- a/packages/app/src/lib/workers/asyncChannel.ts
+++ b/packages/app/src/lib/workers/asyncChannel.ts
@@ -1,0 +1,45 @@
+export const END = Symbol();
+export class AsyncChannel<T> {
+  #queue: (T | typeof END)[] = [];
+  #resolvers: ((next: T | typeof END) => void)[] = [];
+
+  push(item: T | typeof END): void {
+    const resolver = this.#resolvers.shift();
+    if (resolver) {
+      resolver(item);
+    } else {
+      this.#queue.push(item);
+    }
+  }
+
+  finish(): void {
+    this.push(END);
+  }
+
+  static single<T>(item: T): AsyncChannel<T> {
+    const channel = new AsyncChannel<T>();
+    channel.push(item);
+    channel.finish();
+    return channel;
+  }
+
+  async next(): Promise<T | typeof END> {
+    const inQueue = this.#queue.shift();
+    if (inQueue) {
+      return inQueue;
+    } else {
+      return new Promise((r) => this.#resolvers.push(r));
+    }
+  }
+
+  async *[Symbol.asyncIterator]() {
+    while (true) {
+      const next = await this.next();
+      if (next == END) {
+        return;
+      } else {
+        yield next;
+      }
+    }
+  }
+}

--- a/packages/app/src/lib/workers/types.ts
+++ b/packages/app/src/lib/workers/types.ts
@@ -75,6 +75,6 @@ export type SqliteWorkerInterface = {
     statement: SqlStatement,
   ): Promise<void>;
   deleteLiveQuery(id: string): Promise<void>;
-  runQuery(statement: SqlStatement): Promise<QueryResult>;
+  runQuery<Row>(statement: SqlStatement): Promise<QueryResult<Row>>;
   runSavepoint(savepoint: Savepoint): Promise<void>;
 };


### PR DESCRIPTION
- Fetch all missing profiles up instead of during event→sql materialization.
- Remove unnecessary subquery on message author assignment
- Refactor backfill / materialization process to perform fetching, sql materialization, and sql application asynchronously.

It can now backfill 55k discord message import ( 121k events ) in 12 seconds on my local dev.