### PR TITLE
fix: lock spaces to be publicly discoverable for now.

### DIFF
--- a/packages/app/src/routes/(app)/new/+page.svelte
+++ b/packages/app/src/routes/(app)/new/+page.svelte
@@ -331,14 +331,15 @@
             id="discovery"
             aria-labelledby="discovery-label"
             variant="secondary"
-            bind:checked={isDiscoverable}
+            checked={isDiscoverable}
+            disabled={true}
           />
           <Label
             id="discovery-label"
             for="discovery"
             class="text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
           >
-            Allow space to be publicly discoverable
+            Allow space to be publicly discoverable.
           </Label>
         </div>
       </div>


### PR DESCRIPTION
Don't allow unlisted spaces for now, so that we don't give any sense of privacy whatsoever at the moment. We don't have a public listing right now, but we also haven't been paying attention to whether or not that checkbox was checked at all.