### PR TITLE
fix: fix joining spaces with and without handles.

### DIFF
--- a/packages/app/src/lib/lexicons.ts
+++ b/packages/app/src/lib/lexicons.ts
@@ -37,6 +37,40 @@ export const lexicons: LexiconDoc[] = [
   },
   {
     lexicon: 1,
+    id: "space.roomy.stream.handle",
+    defs: {
+      main: {
+        type: "record",
+        record: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    lexicon: 1,
+    id: "space.roomy.stream.handle.dev",
+    defs: {
+      main: {
+        type: "record",
+        record: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    lexicon: 1,
     id: "space.roomy.upload",
     defs: {
       main: {

--- a/packages/app/src/lib/workers/backendWorker.ts
+++ b/packages/app/src/lib/workers/backendWorker.ts
@@ -555,18 +555,28 @@ function connectMessagePort(port: MessagePortApi) {
               })
             ).data.did;
 
-        const resp = await state.agent.com.atproto.repo.getRecord({
-          collection: CONFIG.streamHandleNsid,
-          repo: did,
-          rkey: "self",
-        });
-        return resp.data.value?.id
+        const resp = await state.agent.com.atproto.repo.getRecord(
+          {
+            collection: CONFIG.streamHandleNsid,
+            repo: did,
+            rkey: "self",
+          },
+          {
+            headers: {
+              "atproto-proxy": `${did}#atproto_pds`,
+            },
+          },
+        );
+
+        const result = resp.data.value?.id
           ? {
               spaceId: resp.data.value.id as string,
               handleDid: did,
             }
           : undefined;
-      } catch (_) {
+        return result;
+      } catch (e) {
+        console.warn("Error resolving space from handle", e);
         return undefined;
       }
     },

--- a/packages/app/src/routes/(app)/[space=hashOrDomain]/+page.svelte
+++ b/packages/app/src/routes/(app)/[space=hashOrDomain]/+page.svelte
@@ -19,32 +19,31 @@
   let inviteSpaceName = $derived(page.url.searchParams.get("name"));
   let inviteSpaceAvatar = $derived(page.url.searchParams.get("avatar"));
 
-  let spaceFromHandleResp = $derived(
-    !current.space?.id && page.params.space?.includes(".")
-      ? backend.resolveSpaceFromHandleOrDid(page.params.space)
-      : current.space?.id
-        ? { spaceId: current.space.id }
-        : undefined,
-  );
-
   async function joinSpace() {
-    const resp = await spaceFromHandleResp;
-    if (!resp || !backendStatus.personalStreamId) {
-      toast.error("Could not join space. It's possible it does not exist.");
-      return;
-    }
-    await backend.sendEvent(backendStatus.personalStreamId, {
-      ulid: ulid(),
-      parent: undefined,
-      variant: {
-        kind: "space.roomy.space.join.0",
-        data: {
-          spaceId: resp.spaceId,
+    try {
+      const spaceId = page.params.space?.includes(".")
+        ? (await backend.resolveSpaceFromHandleOrDid(page.params.space))
+            ?.spaceId
+        : page.params.space;
+      if (!spaceId || !backendStatus.personalStreamId) {
+        toast.error("Could not join space. It's possible it does not exist.");
+        return;
+      }
+      await backend.sendEvent(backendStatus.personalStreamId, {
+        ulid: ulid(),
+        parent: undefined,
+        variant: {
+          kind: "space.roomy.space.join.0",
+          data: {
+            spaceId,
+          },
         },
-      },
-    });
+      });
+    } catch (e) {
+      console.error(e);
+      toast.error("Could not join space. It's possible it does not exist.");
+    }
   }
-
   const threadsList = new LiveQuery<ThreadInfo>(
     () =>
       sql`

--- a/packages/app/src/routes/(app)/[space=hashOrDomain]/[object=ulid]/+page.svelte
+++ b/packages/app/src/routes/(app)/[space=hashOrDomain]/[object=ulid]/+page.svelte
@@ -44,30 +44,30 @@
   let inviteSpaceName = $derived(page.url.searchParams.get("name"));
   let inviteSpaceAvatar = $derived(page.url.searchParams.get("avatar"));
 
-  let spaceFromHandleResp = $derived(
-    !current.space?.id && page.params.space?.includes(".")
-      ? backend.resolveSpaceFromHandleOrDid(page.params.space)
-      : current.space?.id
-        ? { spaceId: current.space.id }
-        : undefined,
-  );
-
   async function joinSpace() {
-    const resp = await spaceFromHandleResp;
-    if (!resp || !backendStatus.personalStreamId) {
-      toast.error("Could not join space. It's possible it does not exist.");
-      return;
-    }
-    await backend.sendEvent(backendStatus.personalStreamId, {
-      ulid: ulid(),
-      parent: undefined,
-      variant: {
-        kind: "space.roomy.space.join.0",
-        data: {
-          spaceId: resp.spaceId,
+    try {
+      const spaceId = page.params.space?.includes(".")
+        ? (await backend.resolveSpaceFromHandleOrDid(page.params.space))
+            ?.spaceId
+        : page.params.space;
+      if (!spaceId || !backendStatus.personalStreamId) {
+        toast.error("Could not join space. It's possible it does not exist.");
+        return;
+      }
+      await backend.sendEvent(backendStatus.personalStreamId, {
+        ulid: ulid(),
+        parent: undefined,
+        variant: {
+          kind: "space.roomy.space.join.0",
+          data: {
+            spaceId,
+          },
         },
-      },
-    });
+      });
+    } catch (e) {
+      console.error(e);
+      toast.error("Could not join space. It's possible it does not exist.");
+    }
   }
 
   const ref = $derived($scrollContainerRef);


### PR DESCRIPTION
There were some bugs with the space joining and an issue where you could only join spaces by handle if the handle happened to be on the same PDS as you ( due to the confusing way that `getRecord` only gets the record from the PDS you're connected to ).