### PR TITLE
feat: add stubs for Node.js modules and improve Vite configuration 

### DIFF
--- a/packages/app/src/app.html
+++ b/packages/app/src/app.html
@@ -13,7 +13,7 @@
 
     <meta
       name="viewport"
-      content="initial-scale=1, viewport-fit=cover, width=device-width, uc-fitscreen=yes"
+      content="initial-scale=1, viewport-fit=cover, width=device-width"
     />
     <meta name="screen-orientation" content="portrait" />
 

--- a/packages/app/src/lib/components/content/thread/ChatInputArea.svelte
+++ b/packages/app/src/lib/components/content/thread/ChatInputArea.svelte
@@ -29,7 +29,7 @@
   let previewImages: string[] = $state([]);
 
   $effect(() => {
-    console.log("messaging state", messagingState.current);
+    $inspect(messagingState.current);
   });
 
   function getVideoThumbnail(file: File): Promise<string> {

--- a/packages/app/src/lib/components/content/thread/TimelineView.svelte
+++ b/packages/app/src/lib/components/content/thread/TimelineView.svelte
@@ -139,7 +139,7 @@
   import { setInputFocus } from "./ChatInput.svelte";
 
   $effect(() => {
-    console.log("messaging state", messagingState.current);
+    $inspect(messagingState.current);
   });
 
   function startThreading(message?: Message) {

--- a/packages/app/src/lib/queries.svelte.ts
+++ b/packages/app/src/lib/queries.svelte.ts
@@ -235,7 +235,9 @@ $effect.root(() => {
           ? await backend.resolveHandleForSpace(x.id, x.handle_account)
           : undefined,
       })) || [],
-    ).then((s) => (spaces.list = s));
+    ).then((s) => {
+      spaces.list = s;
+    });
   });
 
   // Update the current.space

--- a/packages/app/src/lib/stubs/fs.ts
+++ b/packages/app/src/lib/stubs/fs.ts
@@ -1,0 +1,5 @@
+// Empty stub for Node.js 'fs' module - not needed in browser
+export default {};
+export const existsSync = () => false;
+export const readFileSync = () => "";
+

--- a/packages/app/src/lib/stubs/path.ts
+++ b/packages/app/src/lib/stubs/path.ts
@@ -1,0 +1,9 @@
+// Empty stub for Node.js 'path' module - not needed in browser
+export default {};
+export const isAbsolute = () => false;
+export const resolve = () => "";
+export const dirname = () => "";
+export const join = () => "";
+export const relative = () => "";
+export const sep = "/";
+

--- a/packages/app/src/lib/stubs/source-map-js.ts
+++ b/packages/app/src/lib/stubs/source-map-js.ts
@@ -1,0 +1,5 @@
+// Empty stub for 'source-map-js' module - not needed in browser
+export default {};
+export const SourceMapConsumer = class {};
+export const SourceMapGenerator = class {};
+

--- a/packages/app/src/lib/stubs/url.ts
+++ b/packages/app/src/lib/stubs/url.ts
@@ -1,0 +1,5 @@
+// Empty stub for Node.js 'url' module - not needed in browser
+export default {};
+export const fileURLToPath = () => "";
+export const pathToFileURL = () => "";
+

--- a/packages/app/static/manifest.json
+++ b/packages/app/static/manifest.json
@@ -19,7 +19,7 @@
   "lang": "en-US",
   "name": "Roomy",
   "short_name": "Roomy",
-  "start_url": "https://roomy.space/home",
+  "start_url": "/home",
   "description": "A shared web space for digital gardening.",
   "id": "com.roomy.chat"
 }

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -5,6 +5,11 @@ import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
 import Icons from "unplugin-icons/vite";
 import { FileSystemIconLoader } from "unplugin-icons/loaders";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export default defineConfig({
   plugins: [
@@ -43,5 +48,15 @@ export default defineConfig({
   },
   optimizeDeps: {
     exclude: ["@sqlite.org/sqlite-wasm"],
+  },
+  resolve: {
+    alias: {
+      // Provide empty stubs for Node.js modules used by postcss (dependency of sanitize-html)
+      // These modules are not needed in the browser and postcss won't actually use them
+      path: resolve(__dirname, "src/lib/stubs/path.ts"),
+      fs: resolve(__dirname, "src/lib/stubs/fs.ts"),
+      url: resolve(__dirname, "src/lib/stubs/url.ts"),
+      "source-map-js": resolve(__dirname, "src/lib/stubs/source-map-js.ts"),
+    },
   },
 });


### PR DESCRIPTION
Cleans up warnings in console log


- Introduced empty stubs for Node.js modules ('fs', 'path', 'url', 'source-map-js') to facilitate browser compatibility.
- Updated Vite configuration to include module resolution for these stubs.
- Cleaned up HTML meta tag for viewport settings.
- Enhanced promise handling in queries.svelte for better readability.
- Replaced console logging with $inspect for messaging state in ChatInputArea and TimelineView components.