### PR TITLE
fix: integrate #509 oauth scope limiting

### DIFF
--- a/packages/app/src/lib/config.ts
+++ b/packages/app/src/lib/config.ts
@@ -1,9 +1,55 @@
-export const CONFIG = {
+const CONFIG = {
   leafUrl: import.meta.env.VITE_LEAF_URL || "leaf-dev.muni.town",
   streamNsid: import.meta.env.VITE_STREAM_NSID || "space.roomy.stream.dev",
   streamHandleNsid:
     import.meta.env.VITE_STREAM_HANDLE_NSID || "space.roomy.stream.handle.dev",
   streamSchemaVersion: "1",
   databaseSchemaVersion: "2",
-  atprotoOauthScope: "atproto transition:generic transition:chat.bsky",
+  leafServerDid: "",
+  atprotoOauthScope: "",
 };
+
+CONFIG.leafServerDid = `did:web:${new URL(CONFIG.leafUrl).hostname}`;
+CONFIG.atprotoOauthScope = [
+  `atproto`, // Required just to login to atproto
+
+  `rpc:app.bsky.actor.getProfile?aud=did:web:api.bsky.app%23bsky_appview`, // Access to query the Bluesky profile
+
+  // These are the scopes needed for accessing Bluesky DMs, but since we don't have the UI for that
+  // yet, lets not ask for permission to it.
+
+  // ...[
+  //   "chat.bsky.actor.deleteAccount",
+  //   "chat.bsky.actor.exportAccountData",
+  //   "chat.bsky.convo.acceptConvo",
+  //   "chat.bsky.convo.deleteMessageForSelf",
+  //   "chat.bsky.convo.getConvoAvailability",
+  //   "chat.bsky.convo.getConvoForMembers",
+  //   "chat.bsky.convo.getConvo",
+  //   "chat.bsky.convo.getLog",
+  //   "chat.bsky.convo.leaveConvo",
+  //   "chat.bsky.convo.listConvos",
+  //   "chat.bsky.convo.muteConvo",
+  //   "chat.bsky.convo.removeReaction",
+  //   "chat.bsky.convo.sendMessageBatch",
+  //   "chat.bsky.convo.unmuteConvo",
+  //   "chat.bsky.convo.addReaction",
+  //   "chat.bsky.convo.updateAllRead",
+  //   "chat.bsky.convo.updateRead",
+  //   "chat.bsky.moderation.getActorMetadata",
+  //   "chat.bsky.moderation.getMessageContext",
+  //   "chat.bsky.moderation.updateActorAccess",
+  // ].map((lxm) => `rpc:${lxm}?aud=did:web:api.bsky.chat%23bsky_chat`),
+
+  "blob:*/*", // Allow all blob uploads
+  "repo:space.roomy.upload", // And creating roomy upload records
+
+  `repo:${CONFIG.streamNsid}`, // Access to the stream collection
+  `repo:${CONFIG.streamHandleNsid}`, // Access to the stream handle collection
+
+  // TODO: For some reason I can't get this to work with a non-wildcard audience. In the future we
+  // should be able to set the audience to the `leafServerDid`.
+  `rpc:town.muni.leaf.authenticate?aud=*`, // Access to authenticate to the leaf server
+].join(" ");
+
+export { CONFIG };

--- a/packages/app/src/lib/workers/backend/client.ts
+++ b/packages/app/src/lib/workers/backend/client.ts
@@ -84,7 +84,8 @@ export class Client {
 
       const leaf = new LeafClient(CONFIG.leafUrl, async () => {
         const resp = await agent?.com.atproto.server.getServiceAuth({
-          aud: `did:web:${new URL(CONFIG.leafUrl).host}`,
+          aud: CONFIG.leafServerDid,
+          lxm: "town.muni.leaf.authenticate",
         });
         if (!resp) throw "Error authenticating for leaf server";
         return resp.data.token;


### PR DESCRIPTION
Worker refactor #492 inadvertently un-created some constants needed for the newly limited OAuth scopes in #509. This restores this 