### PR TITLE
fix: env var host in oauth metadata file

### DIFF
--- a/packages/app/scripts/build-prod.sh
+++ b/packages/app/scripts/build-prod.sh
@@ -2,7 +2,7 @@
 
 npm run build-web-app
 
-target_url=https://roomy.space
+target_url=${OAUTH_HOST:-https://roomy.space}
 
 # Add oauth-client configuration
 echo "{


### PR DESCRIPTION
We have a new staging server at [https://next.roomy.space](https://next.roomy.space). For OAuth to work, the `oauth-client-metadata.json` file needs to contain this hostname, but the script that generated our metadata had [https://roomy.space](https://roomy.space) hardcoded. This fixes with an env var that falls back to [https://roomy.space](https://roomy.space).