### PR TITLE
fix: fix loading spinner on desktop / mobile builds.

### DIFF
--- a/packages/app/build-tmp/index.html
+++ b/packages/app/build-tmp/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-<meta http-equiv="refresh" content="0;url=https://roomy.space">
-</head>
-<body>
-<p>Redirecting...</p>
-</body>
-</html>

--- a/packages/app/src-tauri/build-tmp/index.html
+++ b/packages/app/src-tauri/build-tmp/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=https://roomy.space">
+<script type="text/javascript">window.location.href="https://roomy.space"</script>
+<style>
+  body {
+    background: oklch(15% .004 49.25);
+    height: 100dvh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  @keyframes spin {to {transform: rotate(360deg)}}
+  svg {animation: spin 1s linear infinite;}
+</style>
+</head><body><svg viewBox="0 0 24 24" width="1.2em" height="1.2em" font-size="8em" class="animate-spin text-primary"><path fill="oklch(86.9% .005 56.366)" d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8"></path></svg></body></html>

--- a/packages/app/src-tauri/tauri.conf.json
+++ b/packages/app/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.1.0-alpha-6",
   "identifier": "space.roomy",
   "build": {
-    "frontendDist": "../build-tmp",
+    "frontendDist": "./build-tmp",
     "devUrl": "http://localhost:5173",
     "beforeDevCommand": "pnpm dev"
   },


### PR DESCRIPTION
Temporary fix for #517 by changing the location of tauri's webview to https://roomy.space. Long-term the bug(s) appears to also affect static builds of roomy run with `vite preview`, debugging this has been difficult as it does not produce any console errors.

Tested [and working]
 - [x] .deb linux x86
 - [x] appimage linux x86
 - [x] .apk android
 - [ ] windows (website loaded successfully but also had a spinner)