### PR TITLE
refactor: abstract peer state into helpers with auto status updates.

### DIFF
--- a/packages/app/src/lib/queries/current.svelte.ts
+++ b/packages/app/src/lib/queries/current.svelte.ts
@@ -1,7 +1,7 @@
 import { page } from "$app/state";
 import { peer, peerStatus } from "$lib/workers";
 import { joinedSpaces } from "./spaces.svelte";
-import type { ReactiveAuthState } from "$lib/workers/peer/types";
+import type { AuthStatus } from "$lib/workers/peer/types";
 import type { SpaceIdOrHandle } from "$lib/workers/types";
 import type { SpaceMeta } from "./types";
 import { Handle, type StreamDid, Ulid, type UserDid } from "@roomy/sdk";
@@ -92,7 +92,7 @@ const currentSpace = $derived.by(() => {
         permission[0] ===
           (
             peerStatus.authState as Extract<
-              ReactiveAuthState,
+              AuthStatus,
               { state: "authenticated" }
             >
           ).did && permission[1] === "admin",


### PR DESCRIPTION
This makes sure that we don't accidentally forget to update the reactive status when we change the peer auth / roomy client state.