### PR TITLE
fix: show join space or SpaceNotFound messages as appropriate

### DIFF
--- a/packages/app/src/lib/components/modals/SpaceNotFound.svelte
+++ b/packages/app/src/lib/components/modals/SpaceNotFound.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { Box } from "@foxui/core";
+  import Button from "$lib/components/ui/button/Button.svelte";
+
+  let { message }: { message?: string } = $props();
+
+  const handle = $derived(page.params.space);
+</script>
+
+<div class="flex items-center justify-center h-screen w-full">
+  <Box class="w-[28em] flex flex-col items-center gap-4 p-8">
+    <div class="text-4xl">:(</div>
+    <h2 class="text-lg font-semibold">Space not found</h2>
+    {#if handle}
+      <p class="text-sm text-base-500 dark:text-base-400 text-center">
+        We couldn't find a space at <span
+          class="font-mono bg-base-200 dark:bg-base-800 px-1.5 py-0.5 rounded"
+          >{handle}</span
+        >
+      </p>
+    {/if}
+    {#if message}
+      <p class="text-xs text-base-400 dark:text-base-500 text-center">
+        {message}
+      </p>
+    {/if}
+    <div
+      class="text-sm text-base-500 dark:text-base-400 text-center space-y-1"
+    >
+      <p>This could mean:</p>
+      <ul class="text-left list-disc list-inside">
+        <li>The space doesn't exist yet</li>
+        <li>The handle hasn't been linked to a space</li>
+        <li>The URL may be incorrect</li>
+      </ul>
+    </div>
+    <a href="/home" class="mt-2">
+      <Button variant="blue">Go Home</Button>
+    </a>
+  </Box>
+</div>

--- a/packages/app/src/lib/workers/peer/impl.ts
+++ b/packages/app/src/lib/workers/peer/impl.ts
@@ -659,13 +659,23 @@ export class Peer {
       { attributes: { "space.id": currentSpaceIdOrHandle || "none" } },
       ctx,
       async (span) => {
-        const resolved = currentSpaceIdOrHandle
-          ? await this.client.resolveSpaceIdFromDidOrHandle(
-              currentSpaceIdOrHandle,
-            )
-          : undefined;
-        span.end();
-        return resolved?.spaceDid;
+        try {
+          const resolved = currentSpaceIdOrHandle
+            ? await this.client.resolveSpaceIdFromDidOrHandle(
+                currentSpaceIdOrHandle,
+              )
+            : undefined;
+          return resolved?.spaceDid;
+        } catch (e) {
+          console.warn(
+            "[Peer] Could not resolve current space:",
+            currentSpaceIdOrHandle,
+            e,
+          );
+          return undefined;
+        } finally {
+          span.end();
+        }
       },
     );
 

--- a/packages/app/src/routes/(app)/[space=didOrDomain]/+page.svelte
+++ b/packages/app/src/routes/(app)/[space=didOrDomain]/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import { getAppState } from "$lib/queries";
+  import SpaceNotFound from "$lib/components/modals/SpaceNotFound.svelte";
+  import JoinSpaceModal from "$lib/components/modals/JoinSpaceModal.svelte";
+  import MainLayout from "$lib/components/layout/MainLayout.svelte";
+  import { IconLoading } from "@roomy/design/icons";
 
   const app = getAppState();
   import { navigate } from "$lib/utils.svelte";
@@ -17,3 +21,22 @@
     }
   });
 </script>
+
+{#if app.space.status === "error"}
+  <MainLayout>
+    <SpaceNotFound message={app.space.message} />
+  </MainLayout>
+{:else if app.space.status === "invited"}
+  <MainLayout>
+    <JoinSpaceModal />
+  </MainLayout>
+{:else}
+  <MainLayout>
+    <div class="flex items-center justify-center h-full w-full">
+      <IconLoading
+        font-size="2em"
+        class="animate-spin text-primary"
+      />
+    </div>
+  </MainLayout>
+{/if}


### PR DESCRIPTION
Was getting a blank page when navigating to https://roomy.space/roomy.space because I had not joined the space before.

This fix detects and shows the join space dialog as necessary. Also shows a nice "space not found" message for urls like https://roomy.space/foo.bar (also currently a blank page).

(this is my first time poking around this codebase so might be misunderstanding how things work)