### PR TITLE
feat: detect scope mismatch at session restore and silently re-authorize

### DIFF
--- a/packages/app/src/lib/components/user/LoginForm.svelte
+++ b/packages/app/src/lib/components/user/LoginForm.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
   import { env } from "$env/dynamic/public";
   import { peer } from "$lib/workers";
+  import { REDIRECT_AFTER_LOGIN_KEY } from "$lib/utils/storageKeys";
 
   import { Subheading, Label, Avatar, Box, Tabs, toast } from "@foxui/core";
   import { Handle } from "@roomy/sdk";
@@ -32,7 +33,7 @@
 
     if (loading) return;
 
-    localStorage.setItem("redirect-after-login", window.location.href);
+    localStorage.setItem(REDIRECT_AFTER_LOGIN_KEY, window.location.href);
 
     loading = true;
     error = null;

--- a/packages/app/src/lib/utils/scopeCheck.test.ts
+++ b/packages/app/src/lib/utils/scopeCheck.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { checkScopeMismatch } from "./scopeCheck";
+
+describe("checkScopeMismatch", () => {
+  it("returns null when all required scopes are granted", () => {
+    const granted = "atproto blob:*/* rpc:net.openmeet.auth?aud=*";
+    const required = "atproto blob:*/*";
+    expect(checkScopeMismatch(granted, required)).toBeNull();
+  });
+
+  it("returns null when scopes match exactly", () => {
+    const scope = "atproto blob:*/* rpc:net.openmeet.auth?aud=*";
+    expect(checkScopeMismatch(scope, scope)).toBeNull();
+  });
+
+  it("returns missing scopes when required scopes are absent", () => {
+    const granted = "atproto blob:*/*";
+    const required = "atproto blob:*/* rpc:net.openmeet.auth?aud=*";
+    expect(checkScopeMismatch(granted, required)).toEqual([
+      "rpc:net.openmeet.auth?aud=*",
+    ]);
+  });
+
+  it("returns multiple missing scopes", () => {
+    const granted = "atproto";
+    const required = "atproto blob:*/* rpc:net.openmeet.auth?aud=*";
+    expect(checkScopeMismatch(granted, required)).toEqual([
+      "blob:*/*",
+      "rpc:net.openmeet.auth?aud=*",
+    ]);
+  });
+
+  it("ignores scope ordering differences", () => {
+    const granted = "blob:*/* atproto";
+    const required = "atproto blob:*/*";
+    expect(checkScopeMismatch(granted, required)).toBeNull();
+  });
+
+  it("handles extra whitespace gracefully", () => {
+    const granted = "atproto  blob:*/*  ";
+    const required = "atproto blob:*/*";
+    expect(checkScopeMismatch(granted, required)).toBeNull();
+  });
+
+  it("handles empty granted scope", () => {
+    const required = "atproto";
+    expect(checkScopeMismatch("", required)).toEqual(["atproto"]);
+  });
+
+  it("handles empty required scope", () => {
+    expect(checkScopeMismatch("atproto", "")).toBeNull();
+  });
+
+  it("handles both empty", () => {
+    expect(checkScopeMismatch("", "")).toBeNull();
+  });
+
+  it("does not trigger re-auth when granted has extra scopes (scope removal)", () => {
+    const granted = "atproto blob:*/* rpc:old.removed.scope?aud=*";
+    const required = "atproto blob:*/*";
+    expect(checkScopeMismatch(granted, required)).toBeNull();
+  });
+});

--- a/packages/app/src/lib/utils/scopeCheck.ts
+++ b/packages/app/src/lib/utils/scopeCheck.ts
@@ -1,0 +1,14 @@
+/**
+ * Compare granted OAuth scopes against required scopes.
+ * Returns the list of missing scopes, or null if all required scopes are present.
+ * Additive-only: removing a scope from required won't trigger re-auth.
+ */
+export function checkScopeMismatch(
+  grantedScope: string,
+  requiredScope: string,
+): string[] | null {
+  const granted = new Set(grantedScope.split(" ").filter(Boolean));
+  const required = requiredScope.split(" ").filter(Boolean);
+  const missing = required.filter((s) => !granted.has(s));
+  return missing.length > 0 ? missing : null;
+}

--- a/packages/app/src/lib/utils/storageKeys.ts
+++ b/packages/app/src/lib/utils/storageKeys.ts
@@ -1,0 +1,3 @@
+/** Shared localStorage keys used across login/auth flows. */
+export const JUST_LOGGED_IN_KEY = "just-logged-in";
+export const REDIRECT_AFTER_LOGIN_KEY = "redirect-after-login";

--- a/packages/app/src/lib/workers/index.ts
+++ b/packages/app/src/lib/workers/index.ts
@@ -146,7 +146,10 @@ export const peer = tracer.startActiveSpan(
       [sqliteWorkerChannel.port2, workerStatusChannel.port2],
     );
 
-    if (page.route.id !== "/(internal)/oauth/callback") {
+    // Use window.location instead of page.route.id because SvelteKit's
+    // page state isn't resolved yet at module init time, causing the guard
+    // to fail and triggering scope-check redirects on the callback page.
+    if (!window.location.pathname.includes("/oauth/callback")) {
       // Skip scope check if user just completed login (prevents infinite redirect loop).
       // The flag is set by the OAuth callback page and cleared by +layout.svelte
       // after caching the user's profile. TTL prevents a stale flag from permanently
@@ -164,6 +167,10 @@ export const peer = tracer.startActiveSpan(
         )
         .then((result) => {
           if (result.redirectUrl) {
+            // Set just-logged-in BEFORE redirect so the callback page's
+            // module init skips the scope check (page.route.id guard is
+            // unreliable at module load time).
+            localStorage.setItem(JUST_LOGGED_IN_KEY, Date.now().toString());
             localStorage.setItem(
               REDIRECT_AFTER_LOGIN_KEY,
               window.location.pathname || "/home",

--- a/packages/app/src/lib/workers/index.ts
+++ b/packages/app/src/lib/workers/index.ts
@@ -170,6 +170,9 @@ export const peer = tracer.startActiveSpan(
             );
             window.location.href = result.redirectUrl;
           }
+        })
+        .catch((e) => {
+          console.error("Peer initialization failed", e);
         });
     }
 

--- a/packages/app/src/lib/workers/index.ts
+++ b/packages/app/src/lib/workers/index.ts
@@ -146,10 +146,9 @@ export const peer = tracer.startActiveSpan(
       [sqliteWorkerChannel.port2, workerStatusChannel.port2],
     );
 
-    // Use window.location instead of page.route.id because SvelteKit's
-    // page state isn't resolved yet at module init time, causing the guard
-    // to fail and triggering scope-check redirects on the callback page.
-    if (!window.location.pathname.includes("/oauth/callback")) {
+    // window.location instead of page.route.id — at module init time the
+    // router may not have resolved yet, so page.route.id can be stale.
+    if (!window.location.pathname.startsWith("/oauth/callback")) {
       // Skip scope check if user just completed login (prevents infinite redirect loop).
       // The flag is set by the OAuth callback page and cleared by +layout.svelte
       // after caching the user's profile. TTL prevents a stale flag from permanently

--- a/packages/app/src/lib/workers/index.ts
+++ b/packages/app/src/lib/workers/index.ts
@@ -9,6 +9,10 @@ import type {
 } from "./peer/types";
 import type { SqliteStatus } from "./sqlite/types";
 import { CONFIG, flags } from "../config";
+import {
+  JUST_LOGGED_IN_KEY,
+  REDIRECT_AFTER_LOGIN_KEY,
+} from "../utils/storageKeys";
 import { context, trace } from "@opentelemetry/api";
 import { page } from "$app/state";
 import { Peer, peerStatusChannel } from "./peer/impl";
@@ -143,7 +147,30 @@ export const peer = tracer.startActiveSpan(
     );
 
     if (page.route.id !== "/(internal)/oauth/callback") {
-      peer.initializePeer();
+      // Skip scope check if user just completed login (prevents infinite redirect loop).
+      // The flag is set by the OAuth callback page and cleared by +layout.svelte
+      // after caching the user's profile. TTL prevents a stale flag from permanently
+      // disabling scope checks (e.g., if the user closed the tab mid-flow).
+      const JUST_LOGGED_IN_TTL_MS = 60_000;
+      const justLoggedInAt = localStorage.getItem(JUST_LOGGED_IN_KEY);
+      const skipScopeCheck =
+        justLoggedInAt !== null &&
+        Date.now() - Number(justLoggedInAt) < JUST_LOGGED_IN_TTL_MS;
+
+      peer
+        .initializePeer(
+          undefined,
+          skipScopeCheck ? { skipScopeCheck: true } : undefined,
+        )
+        .then((result) => {
+          if (result.redirectUrl) {
+            localStorage.setItem(
+              REDIRECT_AFTER_LOGIN_KEY,
+              window.location.pathname || "/home",
+            );
+            window.location.href = result.redirectUrl;
+          }
+        });
     }
 
     span.end();

--- a/packages/app/src/lib/workers/peer/impl.ts
+++ b/packages/app/src/lib/workers/peer/impl.ts
@@ -60,6 +60,7 @@ import { createOauthClient, oauthDb } from "./oauth";
 import { Agent, CredentialSession } from "@atproto/api";
 import { lexicons } from "$lib/lexicons";
 import { checkScopeMismatch } from "$lib/utils/scopeCheck";
+import { OAuthSession } from "@atproto/oauth-client";
 import type { SessionManager } from "@atproto/api/dist/session-manager";
 
 /** Helper type that is a session manager where the DID is asserted to be defined. */
@@ -407,35 +408,30 @@ export class Peer {
 
       // Check for stale OAuth scopes and redirect for re-authorization if needed.
       // Skipped right after login to prevent infinite redirect loops.
-      if (!opts?.skipScopeCheck) {
-        const hasGetTokenInfo =
-          "getTokenInfo" in session &&
-          typeof session.getTokenInfo === "function";
+      // Only OAuthSession has token info; CredentialSession (app passwords) does not.
+      if (!opts?.skipScopeCheck && session instanceof OAuthSession) {
+        try {
+          const tokenInfo = await session.getTokenInfo(false);
+          const missing = checkScopeMismatch(
+            tokenInfo.scope,
+            CONFIG.atprotoOauthScope,
+          );
 
-        if (hasGetTokenInfo) {
-          try {
-            const tokenInfo = await (session as any).getTokenInfo(false);
-            const missing = checkScopeMismatch(
-              tokenInfo.scope,
-              CONFIG.atprotoOauthScope,
-            );
-
-            if (missing) {
-              console.info("Scope mismatch detected, re-authorizing", {
-                missing,
-              });
-              const oauth = await createOauthClient();
-              const redirectUrl = await oauth.authorize(session.did, {
-                scope: CONFIG.atprotoOauthScope,
-              });
-              return { redirectUrl: redirectUrl.href };
-            }
-          } catch (e) {
-            console.warn(
-              "Scope check failed, proceeding with existing session",
-              e,
-            );
+          if (missing) {
+            console.info("Scope mismatch detected, re-authorizing", {
+              missing,
+            });
+            const oauth = await createOauthClient();
+            const redirectUrl = await oauth.authorize(session.did, {
+              scope: CONFIG.atprotoOauthScope,
+            });
+            return { redirectUrl: redirectUrl.href };
           }
+        } catch (e) {
+          console.warn(
+            "Scope check failed, proceeding with existing session",
+            e,
+          );
         }
       }
 

--- a/packages/app/src/lib/workers/peer/impl.ts
+++ b/packages/app/src/lib/workers/peer/impl.ts
@@ -411,6 +411,7 @@ export class Peer {
       // Only OAuthSession has token info; CredentialSession (app passwords) does not.
       if (!opts?.skipScopeCheck && session instanceof OAuthSession) {
         try {
+          // false = don't refresh the token before reading scope info
           const tokenInfo = await session.getTokenInfo(false);
           const missing = checkScopeMismatch(
             tokenInfo.scope,

--- a/packages/app/src/lib/workers/peer/impl.ts
+++ b/packages/app/src/lib/workers/peer/impl.ts
@@ -59,6 +59,7 @@ import { logMaterializationResult } from "../materializationLogging";
 import { createOauthClient, oauthDb } from "./oauth";
 import { Agent, CredentialSession } from "@atproto/api";
 import { lexicons } from "$lib/lexicons";
+import { checkScopeMismatch } from "$lib/utils/scopeCheck";
 import type { SessionManager } from "@atproto/api/dist/session-manager";
 
 /** Helper type that is a session manager where the DID is asserted to be defined. */
@@ -170,8 +171,8 @@ export class Peer {
    * */
   getPeerInterface(this: Peer): PeerInterface {
     return {
-      initializePeer: (oauthCallbackSearchParams) =>
-        this.initializePeer(oauthCallbackSearchParams),
+      initializePeer: (oauthCallbackSearchParams, opts) =>
+        this.initializePeer(oauthCallbackSearchParams, opts),
       login: async (handle) => this.login(handle),
       logout: async () => await this.logout(),
       setSpaceHandle: (spaceDid, handle) => {
@@ -384,7 +385,8 @@ export class Peer {
    * */
   private async initializePeer(
     oauthCallbackParams?: string,
-  ): Promise<{ did?: string }> {
+    opts?: { skipScopeCheck?: boolean },
+  ): Promise<{ did?: string; redirectUrl?: string }> {
     let [initSpan, ctx] = tracer.startActiveSpan(
       "Initialize Peer",
       (span) => [span, context.active()] as const,
@@ -395,14 +397,46 @@ export class Peer {
     });
 
     return context.with(ctx, async () => {
-      // attempt to authenticate using a previous session or the oauth callback
       const session = await this.authenticate(oauthCallbackParams);
 
-      // If we did not recieve a session, then set our state to unauthenticated
       if (!session) {
         console.info("Not authenticated");
         this.#auth.current = { state: "unauthenticated" };
         return {};
+      }
+
+      // Check for stale OAuth scopes and redirect for re-authorization if needed.
+      // Skipped right after login to prevent infinite redirect loops.
+      if (!opts?.skipScopeCheck) {
+        const hasGetTokenInfo =
+          "getTokenInfo" in session &&
+          typeof session.getTokenInfo === "function";
+
+        if (hasGetTokenInfo) {
+          try {
+            const tokenInfo = await (session as any).getTokenInfo(false);
+            const missing = checkScopeMismatch(
+              tokenInfo.scope,
+              CONFIG.atprotoOauthScope,
+            );
+
+            if (missing) {
+              console.info("Scope mismatch detected, re-authorizing", {
+                missing,
+              });
+              const oauth = await createOauthClient();
+              const redirectUrl = await oauth.authorize(session.did, {
+                scope: CONFIG.atprotoOauthScope,
+              });
+              return { redirectUrl: redirectUrl.href };
+            }
+          } catch (e) {
+            console.warn(
+              "Scope check failed, proceeding with existing session",
+              e,
+            );
+          }
+        }
       }
 
       // If we have a session, update our state to authenticated

--- a/packages/app/src/lib/workers/peer/types.ts
+++ b/packages/app/src/lib/workers/peer/types.ts
@@ -36,7 +36,10 @@ export type PeerInterface = {
    * If `oauthCallbackSearchParams` is not provided, then it will try to restore the previous
    * session and initialize as unauthenticated if that is not possible.
    * */
-  initializePeer(oauthCallbackSearchParams?: string): Promise<{ did?: string }>;
+  initializePeer(
+    oauthCallbackSearchParams?: string,
+    opts?: { skipScopeCheck?: boolean },
+  ): Promise<{ did?: string; redirectUrl?: string }>;
   /** Get the login redirect URL for the user with the given handle. */
   login(username: Handle): Promise<string>;
   /** Logout of the existing user session. */

--- a/packages/app/src/routes/(app)/+layout.svelte
+++ b/packages/app/src/routes/(app)/+layout.svelte
@@ -12,6 +12,7 @@
   import { IconLoading } from "@roomy/design/icons";
   import Error from "$lib/components/modals/Error.svelte";
   import { AppState, setAppState } from "$lib/queries";
+  import { JUST_LOGGED_IN_KEY } from "$lib/utils/storageKeys";
 
   const app = new AppState();
   setAppState(app);
@@ -21,7 +22,7 @@
     if (
       peerStatus.authState?.state === "authenticated" &&
       peerStatus.profile &&
-      localStorage.getItem("just-logged-in") != undefined
+      localStorage.getItem(JUST_LOGGED_IN_KEY) !== null
     ) {
       localStorage.setItem(
         `last-login`,
@@ -31,7 +32,7 @@
           avatar: peerStatus.profile.avatar,
         }),
       );
-      localStorage.removeItem("just-logged-in");
+      localStorage.removeItem(JUST_LOGGED_IN_KEY);
     }
   });
 

--- a/packages/app/src/routes/(internal)/oauth/callback/+page.svelte
+++ b/packages/app/src/routes/(internal)/oauth/callback/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { peer } from "$lib/workers";
+  import { JUST_LOGGED_IN_KEY, REDIRECT_AFTER_LOGIN_KEY } from "$lib/utils/storageKeys";
   import { Alert } from "$lib/components/ui/alert";
   import Button from "$lib/components/ui/button/Button.svelte";
   import { trace, context, SpanStatusCode } from "@opentelemetry/api";
@@ -24,8 +25,8 @@
             span.setStatus({ code: SpanStatusCode.OK });
             span.end();
 
-            localStorage.setItem("just-logged-in", "1");
-            goto(localStorage.getItem("redirect-after-login") || "/home");
+            localStorage.setItem(JUST_LOGGED_IN_KEY, Date.now().toString());
+            goto(localStorage.getItem(REDIRECT_AFTER_LOGIN_KEY) || "/home");
           })
           .catch((e) => {
             error = e.toString();

--- a/packages/app/src/routes/(internal)/oauth/callback/+page.svelte
+++ b/packages/app/src/routes/(internal)/oauth/callback/+page.svelte
@@ -19,7 +19,7 @@
         const searchParams = new URL(globalThis.location.href).searchParams;
 
         peer
-          .initializePeer(searchParams.toString())
+          .initializePeer(searchParams.toString(), { skipScopeCheck: true })
           .then(({ did }) => {
             span.setAttribute("userDid", did || "");
             span.setStatus({ code: SpanStatusCode.OK });


### PR DESCRIPTION
## Summary

Detects when the app requires OAuth scopes that the current session doesn't have (e.g., after a deploy adds a new scope) and redirects through PDS authorization so users are prompted to approve them.

### How it works

- After `oauth.restore()`, compares granted scopes via `getTokenInfo()` against `CONFIG.atprotoOauthScope`
- If missing scopes found, redirects through `oauth.authorize()` for re-authorization
- `just-logged-in` localStorage flag (with 60s TTL) prevents infinite redirect loops
- Scope check lives in `initializePeer()` — `authenticate()` stays as a simple `Session | null` function
- Additive-only: removing a scope from the config won't trigger re-auth
- If scope check fails for any reason, proceeds with existing session rather than blocking login

## Test plan

- [x] 10 unit tests passing (scope comparison)
- [x] Manual: reload after login — scope check runs, no redirect when scopes match
- [x] Manual: add new scope to config, reload — mismatch detected, redirect triggered
- [x] Manual: just-logged-in guard prevents infinite redirect loop
- [ ] Production: verify re-auth flow when a real new scope is deployed