### PR TITLE
feat: add link embeds.

### DIFF
--- a/packages/app/src/lib/components/content/thread/message/ChatMessage.svelte
+++ b/packages/app/src/lib/components/content/thread/message/ChatMessage.svelte
@@ -169,12 +169,14 @@
     // all remaining potential urls are partials
     if (str.indexOf(".") === -1) return false;
 
-    const res =  UrlRegex.test(str);
-    return res
+    const res = UrlRegex.test(str);
+    return res;
   };
 
-  const links: {url: string, data: Embed}[] | null = $state(hasUrl(message.content) ? [] : null);
-  $inspect(links)
+  const links: { url: string; data: Embed }[] | null = $state(
+    hasUrl(message.content) ? [] : null,
+  );
+  $inspect(links);
 
   function getEmbeds() {
     return Promise.all(
@@ -186,7 +188,7 @@
             ? _url
             : "https://" + _url;
         const data = await getLinkEmbedData(url);
-        if (data) links?.push({url, data})
+        if (data) links?.push({ url, data });
       }),
     );
   }

--- a/packages/app/src/lib/components/content/thread/message/ChatMessage.svelte
+++ b/packages/app/src/lib/components/content/thread/message/ChatMessage.svelte
@@ -57,7 +57,7 @@
   import { Event, newUlid, toBytes, Ulid } from "@roomy/sdk";
   import { page } from "$app/state";
   import { cdnImageUrl } from "$lib/utils.svelte";
-  import { getLinkEmbedData, type Embed } from "$lib/utils/getLinkEmbedData";
+  import { getLinkEmbedData } from "$lib/utils/getLinkEmbedData";
   import IconLucideX from "~icons/lucide/x";
   import LinkCard from "./LinkCard.svelte";
 
@@ -157,30 +157,12 @@
   const UrlRegex =
     /<?(https?:\/\/)*[a-z0-9][-a-z0-9]*\.[a-z]{2,}[^\s]*[a-zA-Z0-9\/]>?/gi;
 
-  const hasUrl = (str: string): boolean => {
-    const http = str.indexOf("http");
-    if (
-      http !== -1 &&
-      (str.substring(http + 4, http + 7) === "://" ||
-        str.substring(http + 4, http + 8) === "s://")
-    ) {
-      return true;
-    }
-    // all remaining potential urls are partials
-    if (str.indexOf(".") === -1) return false;
-
-    const res = UrlRegex.test(str);
-    return res;
-  };
-
-  const links: { url: string; data: Embed }[] | null = $state(
-    hasUrl(message.content) ? [] : null,
-  );
-  $inspect(links);
-
-  function getEmbeds() {
-    return Promise.all(
-      (message.content.match(UrlRegex) ?? []).map(async (_url) => {
+  const linkUrls = $derived([
+    ...message.content.matchAll(UrlRegex).map((x) => x[0]),
+  ]);
+  const linkEmbeds = $derived(
+    Promise.all(
+      linkUrls.map(async (_url) => {
         if (_url.startsWith("<") && _url.endsWith(">")) return;
 
         let url =
@@ -188,13 +170,10 @@
             ? _url
             : "https://" + _url;
         const data = await getLinkEmbedData(url);
-        if (data) links?.push({ url, data });
+        return { url, data };
       }),
-    );
-  }
-  $effect(() => {
-    if (links) getEmbeds();
-  });
+    ),
+  );
 </script>
 
 {#snippet messageBox()}
@@ -334,21 +313,25 @@
               </div>
             {/if} -->
           {/if}
-          {#if links && links.length > 0}
-            <div class="pr-2 flex gap-1 items-start">
-              <div class="">
-                {#each links as { url, data }}
-                  <div class="py-1">
-                    <LinkCard embed={data} {url} />
-                  </div>
-                {/each}
+          {#await linkEmbeds then links}
+            {#if links && links.filter((x) => !!x?.data).length > 0}
+              <div class="pr-2 flex gap-1 items-start">
+                <div class="">
+                  {#each links as link}
+                    {#if link && link.data}
+                      <div class="py-1">
+                        <LinkCard embed={link.data} url={link.url} />
+                      </div>
+                    {/if}
+                  {/each}
+                </div>
+                <button
+                  class="opacity-0 hover:opacity-100 cursor-pointer transition-opacity ease-in-out duration-75"
+                  ><IconLucideX /></button
+                >
               </div>
-              <button
-                class="opacity-0 hover:opacity-100 cursor-pointer transition-opacity ease-in-out duration-75"
-                ><IconLucideX /></button
-              >
-            </div>
-          {/if}
+            {/if}
+          {/await}
         </div>
 
         <!-- Media -->

--- a/packages/app/src/lib/components/content/thread/message/ChatMessage.svelte
+++ b/packages/app/src/lib/components/content/thread/message/ChatMessage.svelte
@@ -160,9 +160,9 @@
   const hasUrl = (str: string): boolean => {
     const http = str.indexOf("http");
     if (
-      http === -1 &&
-      (str[http + 4] === ":" ||
-        (str[http + 4] === "s" && str[http + 5] === ":"))
+      http !== -1 &&
+      (str.substring(http + 4, http + 7) === "://" ||
+        str.substring(http + 4, http + 8) === "s://")
     ) {
       return true;
     }

--- a/packages/app/src/lib/components/content/thread/message/ChatMessage.svelte
+++ b/packages/app/src/lib/components/content/thread/message/ChatMessage.svelte
@@ -57,6 +57,9 @@
   import { Event, newUlid, toBytes, Ulid } from "@roomy/sdk";
   import { page } from "$app/state";
   import { cdnImageUrl } from "$lib/utils.svelte";
+  import { getLinkEmbedData, type Embed } from "$lib/utils/getLinkEmbedData";
+  import IconLucideX from "~icons/lucide/x";
+  import LinkCard from "./LinkCard.svelte";
 
   let {
     message,
@@ -151,6 +154,45 @@
   function cancelEditing() {
     onCancelEdit();
   }
+  const UrlRegex =
+    /<?(https?:\/\/)*[a-z0-9][-a-z0-9]*\.[a-z]{2,}[^\s]*[a-zA-Z0-9\/]>?/gi;
+
+  const hasUrl = (str: string): boolean => {
+    const http = str.indexOf("http");
+    if (
+      http === -1 &&
+      (str[http + 4] === ":" ||
+        (str[http + 4] === "s" && str[http + 5] === ":"))
+    ) {
+      return true;
+    }
+    // all remaining potential urls are partials
+    if (str.indexOf(".") === -1) return false;
+
+    const res =  UrlRegex.test(str);
+    return res
+  };
+
+  const links: {url: string, data: Embed}[] | null = $state(hasUrl(message.content) ? [] : null);
+  $inspect(links)
+
+  function getEmbeds() {
+    return Promise.all(
+      (message.content.match(UrlRegex) ?? []).map(async (_url) => {
+        if (_url.startsWith("<") && _url.endsWith(">")) return;
+
+        let url =
+          _url.startsWith("http://") || _url.startsWith("https://")
+            ? _url
+            : "https://" + _url;
+        const data = await getLinkEmbedData(url);
+        if (data) links?.push({url, data})
+      }),
+    );
+  }
+  $effect(() => {
+    if (links) getEmbeds();
+  });
 </script>
 
 {#snippet messageBox()}
@@ -289,6 +331,21 @@
                 Edited {@render timestamp(userAccessTimes.current?.updatedAt)}
               </div>
             {/if} -->
+          {/if}
+          {#if links && links.length > 0}
+            <div class="pr-2 flex gap-1 items-start">
+              <div class="">
+                {#each links as { url, data }}
+                  <div class="py-1">
+                    <LinkCard embed={data} {url} />
+                  </div>
+                {/each}
+              </div>
+              <button
+                class="opacity-0 hover:opacity-100 cursor-pointer transition-opacity ease-in-out duration-75"
+                ><IconLucideX /></button
+              >
+            </div>
           {/if}
         </div>
 

--- a/packages/app/src/lib/components/content/thread/message/LinkCard.svelte
+++ b/packages/app/src/lib/components/content/thread/message/LinkCard.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import type {EdgeLink} from "$lib/workers/materializer"
+  let {
+    embed: e,
+    url,
+  }: {
+    embed: EdgeLink['data'];
+    url: string;
+  } = $props();
+
+  /** add value with separator if it is not undefined */
+  const cr = (value: string | undefined, seperator = ""): string =>
+    value !== undefined ? ` ${seperator} ${value}` : "";
+</script>
+
+<!--TODO: Switch breakpoints to container queries -->
+<div
+  class="not-prose max-w-[70ch] rounded-sm border-l-4 border-l-base-300 dark:border-l-base-700 bg-base-100/50 dark:bg-base-900/50 flex flex-col justify-stretch gap-4 min-[500px]:flex-row"
+>
+  <div class="min-w-0 flex-1 px-3 py-2 flex flex-col">
+    {#if e}
+      <p class="mb-1 mt-0 text-sm leading-none opacity-70">
+        {cr(e.p?.n)}
+        {cr(e.au?.n, "-")}
+      </p>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="mb-1 mt-1 line-clamp-2 max-w-prose leading-snug text-accent-600 dark:text-accent-400 hover:text-primary-focus font-bold"
+      >
+        {e.t}
+      </a>
+      <p class="my-0 line-clamp-2 max-w-prose text-sm leading-tight">
+        {cr(e.d)}
+      </p>
+      <div class="grow py-2"></div>
+      {#if e.footer}
+        <p class="mt-2 mb-0 text-sm">{e.footer.t}</p>
+      {/if}
+    {/if}
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-sm leading-tight underline text-base-600 dark:text-base-400"
+    >
+      {url}
+    </a>
+  </div>
+
+  {#if e}
+    {#if e.imgs && e.imgs.length}
+      <div class=" w-full flex-shrink-0 p-2 min-[500px]:max-w-40">
+        <img
+          alt={e.imgs[0]?.d ?? ""}
+          class="m-0 h-full w-full rounded object-cover"
+          src={e.imgs[0]?.u}
+        />
+      </div>
+    {/if}
+    {#if e.vid}
+      <div class=" w-full flex-shrink-0 p-2 min-[500px]:max-w-40">
+        <video
+          muted
+          class="my-0 h-full w-full rounded object-cover"
+          poster={e.thumb?.u}
+          src={e.vid.u}
+        >
+        </video>
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/packages/app/src/lib/config.ts
+++ b/packages/app/src/lib/config.ts
@@ -42,6 +42,7 @@ const CONFIG = {
   leafServerDid: "",
   openmeetServiceDid: "",
   atprotoOauthScope: "",
+  embedServer: import.meta.env.VITE_EMBED_SERVER || "https://embed.internal.weird.one"
 };
 
 CONFIG.leafServerDid = `did:web:${new URL(CONFIG.leafUrl).hostname}`;

--- a/packages/app/src/lib/utils/getLinkEmbedData.ts
+++ b/packages/app/src/lib/utils/getLinkEmbedData.ts
@@ -1,3 +1,4 @@
+import { dev } from "$app/environment";
 import type { Embed } from "$lib/types/embed-sdk";
 
 export const cache = new Map<string, Embed | null>();
@@ -6,7 +7,7 @@ export const getLinkEmbedData = (url: string) => {
   let data = cache.get(url);
   if (data !== undefined) return data;
 
-  return fetch("https://embed.internal.weird.one?lang=en", {
+  return fetch(dev ? "/api/og" : "https://embed.internal.weird.one?lang=en", {
     method: "POST",
     headers: {
       "Content-Type": "text/plain",

--- a/packages/app/src/lib/utils/getLinkEmbedData.ts
+++ b/packages/app/src/lib/utils/getLinkEmbedData.ts
@@ -26,6 +26,7 @@ export const getLinkEmbedData = (url: string) => {
         // Embed server has no data for the given url.
         // Unlikely to be any data in the future
         cache.set(url, null);
+        return null
       }
     })
     .catch((err) => {
@@ -33,8 +34,8 @@ export const getLinkEmbedData = (url: string) => {
         console.error(`${err.message} caused by '${err.cause}'`);
         // Avoid retrying urls with Network Errors until next refresh
         // Might have data later.
-        cache.set(url, null);
-      } else throw new Error(err as unknown as string);
-      return null;
+      }
+      console.error(err)
+      return undefined
     });
 };

--- a/packages/app/src/lib/utils/getLinkEmbedData.ts
+++ b/packages/app/src/lib/utils/getLinkEmbedData.ts
@@ -1,12 +1,14 @@
-import { dev } from "$app/environment";
+import { CONFIG } from "$lib/config";
 
 export const cache = new Map<string, Embed | null>();
+
+const getLocale = () => navigator.languages?.[0] || navigator.language || "en";
 
 export const getLinkEmbedData = (url: string) => {
   let data = cache.get(url);
   if (data !== undefined) return data;
 
-  return fetch(dev ? "/api/og" : "https://embed.internal.weird.one?lang=en", {
+  return fetch(`${CONFIG.embedServer}?lang=${getLocale()}`, {
     method: "POST",
     headers: {
       "Content-Type": "text/plain",
@@ -25,7 +27,7 @@ export const getLinkEmbedData = (url: string) => {
         // Embed server has no data for the given url.
         // Unlikely to be any data in the future
         cache.set(url, null);
-        return null
+        return null;
       }
     })
     .catch((err) => {
@@ -34,8 +36,8 @@ export const getLinkEmbedData = (url: string) => {
         // Avoid retrying urls with Network Errors until next refresh
         // Might have data later.
       }
-      console.error(err)
-      return undefined
+      console.error(err);
+      return undefined;
     });
 };
 

--- a/packages/app/src/lib/utils/getLinkEmbedData.ts
+++ b/packages/app/src/lib/utils/getLinkEmbedData.ts
@@ -1,5 +1,4 @@
 import { dev } from "$app/environment";
-import type { Embed } from "$lib/types/embed-sdk";
 
 export const cache = new Map<string, Embed | null>();
 
@@ -39,3 +38,110 @@ export const getLinkEmbedData = (url: string) => {
       return undefined
     });
 };
+
+/* from Lantern-chat/embed-sdk https://github.com/Lantern-chat/embed-service/blob/7ae895a7d41c17e7cee72bbe7aab1d5b8650d047/embed-sdk/index.d.ts */
+
+type Timestamp = string;
+
+export type EmbedType = "img" | "audio" | "vid" | "html" | "link" | "article";
+
+/** Bitflags for EmbedFlags */
+export const enum EmbedFlags {
+  /** This embed contains spoilered content and should be displayed as such */
+  SPOILER = 0x1,
+  /**
+   * This embed may contain content marked as "adult"
+   *
+   * NOTE: This is not always accurate, and is provided on a best-effort basis
+   */
+  ADULT = 0x2,
+  /**
+   * This embed contains graphics content such as violence or gore
+   *
+   * NOTE: This is not always accurate, and is provided on a best-effort basis
+   */
+  GRAPHIC = 0x4,
+  /** All bitflags of EmbedFlags */
+  ALL = 0x7,
+}
+
+export interface BasicEmbedMedia {
+  u: string;
+  /** Non-visible description of the embedded media */
+  d?: string;
+  /** Cryptographic signature for use with the proxy server */
+  s?: string;
+  /** height */
+  h?: number;
+  /** width */
+  w?: number;
+  m?: string;
+}
+
+export interface EmbedMedia extends BasicEmbedMedia {
+  a?: BasicEmbedMedia[];
+}
+
+export interface EmbedAuthor {
+  n: string;
+  u?: string;
+  i?: EmbedMedia;
+}
+
+export interface EmbedProvider {
+  n?: string;
+  u?: string;
+  i?: EmbedMedia;
+}
+
+export interface EmbedField {
+  n?: string;
+  v?: string;
+  img?: EmbedMedia;
+  /** Should use block-formatting */
+  b?: boolean;
+}
+
+export interface EmbedFooter {
+  t: string;
+  i?: EmbedMedia;
+}
+
+/**
+ * An embed is metadata taken from a given URL by loading said URL, parsing any meta tags, and fetching
+ * extra information from oEmbed sources.
+ */
+export interface EmbedV1 {
+  /** Timestamp when the embed was retrieved */
+  ts: Timestamp;
+  /** Embed type */
+  ty: EmbedType;
+  f?: EmbedFlags;
+  /** URL fetched */
+  u?: string;
+  /** Canonical URL */
+  c?: string;
+  t?: string;
+  /** Description, usually from the Open-Graph API */
+  d?: string;
+  /** Accent Color */
+  ac?: number;
+  au?: EmbedAuthor;
+  /** oEmbed Provider */
+  p?: EmbedProvider;
+  /**
+   * HTML and similar objects
+   *
+   * See: <https://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/>
+   */
+  obj?: EmbedMedia;
+  /** Contains images for the embed */
+  imgs?: EmbedMedia[];
+  audio?: EmbedMedia;
+  vid?: EmbedMedia;
+  thumb?: EmbedMedia;
+  fields?: EmbedField[];
+  footer?: EmbedFooter;
+}
+
+export type Embed = { v: "1" } & EmbedV1;

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -52,6 +52,15 @@ export default defineConfig({
   },
   server: {
     host: "127.0.0.1",
+    // Uncomment to test embeds locally
+    /* proxy: {
+      '/api/og': {
+        target: 'https://embed.internal.weird.one?lang=en',
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/api\/og/, ''),
+      }
+    } */
   },
   optimizeDeps: {
     exclude: ["@sqlite.org/sqlite-wasm"],

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -52,15 +52,6 @@ export default defineConfig({
   },
   server: {
     host: "127.0.0.1",
-    // Uncomment to test embeds locally
-    /* proxy: {
-      '/api/og': {
-        target: 'https://embed.internal.weird.one?lang=en',
-        changeOrigin: true,
-        secure: true,
-        rewrite: (path) => path.replace(/^\/api\/og/, ''),
-      }
-    } */
   },
   optimizeDeps: {
     exclude: ["@sqlite.org/sqlite-wasm"],


### PR DESCRIPTION
Splits out link embed cards (#366) from previous pull-request #484. embed data is pulled per message and added to the card with only automatic browser caching for persistence.