### PR TITLE
feat(calendar): lazy-load events by date range with cache-first refresh

### DIFF
--- a/packages/app/src/lib/queries/calendar.svelte.ts
+++ b/packages/app/src/lib/queries/calendar.svelte.ts
@@ -20,36 +20,3 @@ export function calendarLinkQuery(streamId: string | undefined) {
     `,
   );
 }
-
-export interface CalendarEvent {
-  [key: string]: unknown;
-  entity: string;
-  slug: string;
-  name: string;
-  startDate: string;
-  endDate: string | null;
-  location: string | null;
-  locationOnline: string | null;
-  status: string;
-  syncedAt: number;
-}
-
-export function calendarEventsQuery(streamId: string | undefined) {
-  return new LiveQuery<CalendarEvent>(
-    () => sql`
-      select
-        entity,
-        slug,
-        name,
-        start_date as startDate,
-        end_date as endDate,
-        location,
-        location_online as locationOnline,
-        status,
-        synced_at as syncedAt
-      from comp_calendar_event
-      where entity like ${streamId + ":%"}
-      order by start_date asc
-    `,
-  );
-}

--- a/packages/app/src/lib/services/calendar-utils.test.ts
+++ b/packages/app/src/lib/services/calendar-utils.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect } from "vitest";
+import {
+  statusClass,
+  mapToCalEvent,
+  isRangeFresh,
+  pruneExpiredRanges,
+  type FetchedRange,
+} from "./calendar-utils";
+
+describe("statusClass", () => {
+  test("defaults to ec-status-scheduled for undefined", () => {
+    expect(statusClass(undefined)).toBe("ec-status-scheduled");
+  });
+
+  test("normalizes lexicon token with hash", () => {
+    expect(statusClass("community.lexicon.calendar.event#cancelled")).toBe(
+      "ec-status-cancelled",
+    );
+  });
+
+  test("lowercases plain status", () => {
+    expect(statusClass("Published")).toBe("ec-status-published");
+  });
+});
+
+describe("mapToCalEvent", () => {
+  test("maps API response (camelCase fields)", () => {
+    const event = mapToCalEvent({
+      slug: "my-event",
+      name: "My Event",
+      startDate: "2026-03-15T10:00:00.000Z",
+      endDate: "2026-03-15T11:00:00.000Z",
+      location: "Room A",
+      locationOnline: "https://meet.example.com",
+      status: "Published",
+    });
+
+    expect(event.id).toBe("my-event");
+    expect(event.title).toBe("My Event");
+    expect(event.start).toEqual(new Date("2026-03-15T10:00:00.000Z"));
+    expect(event.end).toEqual(new Date("2026-03-15T11:00:00.000Z"));
+    expect(event.className).toBe("ec-status-published");
+    expect(event.extendedProps.location).toBe("Room A");
+    expect(event.extendedProps.locationOnline).toBe("https://meet.example.com");
+  });
+
+  test("maps SQLite row (snake_case fields)", () => {
+    const event = mapToCalEvent({
+      slug: "db-event",
+      name: "DB Event",
+      start_date: "2026-03-15T10:00:00.000Z",
+      end_date: "2026-03-15T11:00:00.000Z",
+      location: null,
+      location_online: "https://zoom.us/123",
+      status: "Published",
+    });
+
+    expect(event.id).toBe("db-event");
+    expect(event.start).toEqual(new Date("2026-03-15T10:00:00.000Z"));
+    expect(event.extendedProps.location).toBeNull();
+    expect(event.extendedProps.locationOnline).toBe("https://zoom.us/123");
+  });
+
+  test("prefixes cancelled events with (Cancelled)", () => {
+    const event = mapToCalEvent({
+      slug: "cancelled-event",
+      name: "Old Meetup",
+      startDate: "2026-03-15T10:00:00.000Z",
+      status: "Cancelled",
+    });
+
+    expect(event.title).toBe("(Cancelled) Old Meetup");
+    expect(event.className).toBe("ec-status-cancelled");
+  });
+
+  test("uses startDate as endDate fallback", () => {
+    const event = mapToCalEvent({
+      slug: "no-end",
+      name: "Quick Event",
+      startDate: "2026-03-15T10:00:00.000Z",
+    });
+
+    expect(event.end).toEqual(event.start);
+  });
+
+  test("defaults status to Published when missing", () => {
+    const event = mapToCalEvent({
+      slug: "no-status",
+      name: "Event",
+      startDate: "2026-03-15T10:00:00.000Z",
+    });
+
+    expect(event.extendedProps.status).toBe("Published");
+    expect(event.className).toBe("ec-status-published");
+  });
+});
+
+describe("isRangeFresh", () => {
+  const STALE_TTL = 5 * 60 * 1000;
+
+  test("returns true when range is covered and within TTL", () => {
+    const ranges: FetchedRange[] = [
+      { start: 100, end: 200, fetchedAt: Date.now() },
+    ];
+    expect(isRangeFresh(ranges, 100, 200, STALE_TTL)).toBe(true);
+  });
+
+  test("returns true when range is a subset of a fetched range", () => {
+    const ranges: FetchedRange[] = [
+      { start: 0, end: 300, fetchedAt: Date.now() },
+    ];
+    expect(isRangeFresh(ranges, 100, 200, STALE_TTL)).toBe(true);
+  });
+
+  test("returns false when range is stale", () => {
+    const ranges: FetchedRange[] = [
+      { start: 100, end: 200, fetchedAt: Date.now() - STALE_TTL - 1 },
+    ];
+    expect(isRangeFresh(ranges, 100, 200, STALE_TTL)).toBe(false);
+  });
+
+  test("returns false when range is not fully covered", () => {
+    const ranges: FetchedRange[] = [
+      { start: 100, end: 150, fetchedAt: Date.now() },
+    ];
+    expect(isRangeFresh(ranges, 100, 200, STALE_TTL)).toBe(false);
+  });
+
+  test("returns false when no ranges exist", () => {
+    expect(isRangeFresh([], 100, 200, STALE_TTL)).toBe(false);
+  });
+});
+
+describe("pruneExpiredRanges", () => {
+  const STALE_TTL = 5 * 60 * 1000;
+
+  test("removes expired ranges", () => {
+    const ranges: FetchedRange[] = [
+      { start: 0, end: 100, fetchedAt: Date.now() - STALE_TTL - 1 },
+      { start: 100, end: 200, fetchedAt: Date.now() },
+    ];
+    const result = pruneExpiredRanges(ranges, STALE_TTL);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.start).toBe(100);
+  });
+
+  test("keeps all fresh ranges", () => {
+    const ranges: FetchedRange[] = [
+      { start: 0, end: 100, fetchedAt: Date.now() },
+      { start: 100, end: 200, fetchedAt: Date.now() },
+    ];
+    expect(pruneExpiredRanges(ranges, STALE_TTL)).toHaveLength(2);
+  });
+
+  test("returns empty array when all expired", () => {
+    const ranges: FetchedRange[] = [
+      { start: 0, end: 100, fetchedAt: Date.now() - STALE_TTL - 1 },
+    ];
+    expect(pruneExpiredRanges(ranges, STALE_TTL)).toHaveLength(0);
+  });
+});

--- a/packages/app/src/lib/services/calendar-utils.ts
+++ b/packages/app/src/lib/services/calendar-utils.ts
@@ -1,0 +1,62 @@
+export type CalEvent = {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  className?: string;
+  extendedProps: Record<string, unknown>;
+};
+
+export type FetchedRange = {
+  start: number;
+  end: number;
+  fetchedAt: number;
+};
+
+export function statusClass(status: string | undefined): string {
+  if (!status) return "ec-status-scheduled";
+  const normalized = status.includes("#") ? status.split("#").pop()! : status;
+  return `ec-status-${normalized.toLowerCase()}`;
+}
+
+export function mapToCalEvent(e: Record<string, unknown>): CalEvent {
+  const status = (e.status as string) ?? "Published";
+  const cancelled = status.toLowerCase() === "cancelled";
+  const name = e.name as string;
+  return {
+    id: e.slug as string,
+    title: cancelled ? `(Cancelled) ${name}` : name,
+    start: new Date((e.startDate ?? e.start_date) as string),
+    end: new Date(
+      ((e.endDate ?? e.end_date) as string) ||
+        ((e.startDate ?? e.start_date) as string),
+    ),
+    className: statusClass(status),
+    extendedProps: {
+      slug: e.slug,
+      location: e.location ?? null,
+      locationOnline: e.locationOnline ?? e.location_online,
+      status,
+    },
+  };
+}
+
+export function isRangeFresh(
+  ranges: FetchedRange[],
+  startMs: number,
+  endMs: number,
+  staleTtl: number,
+): boolean {
+  const now = Date.now();
+  return ranges.some(
+    (r) => r.start <= startMs && r.end >= endMs && now - r.fetchedAt < staleTtl,
+  );
+}
+
+export function pruneExpiredRanges(
+  ranges: FetchedRange[],
+  staleTtl: number,
+): FetchedRange[] {
+  const now = Date.now();
+  return ranges.filter((r) => now - r.fetchedAt < staleTtl);
+}

--- a/packages/app/src/lib/services/openmeet.ts
+++ b/packages/app/src/lib/services/openmeet.ts
@@ -245,11 +245,18 @@ export function openOnOpenMeet(
 
 export async function fetchGroupEvents(
   link: CalendarLink,
+  startDate?: string,
+  endDate?: string,
 ): Promise<Record<string, unknown>[]> {
-  const response = (await openmeetFetch(
-    link,
-    `/api/groups/${link.groupSlug}/events`,
-  )) as Record<string, unknown> | Record<string, unknown>[];
+  const params = new URLSearchParams();
+  if (startDate) params.set("startDate", startDate);
+  if (endDate) params.set("endDate", endDate);
+  const qs = params.toString();
+  const path = `/api/groups/${link.groupSlug}/events${qs ? `?${qs}` : ""}`;
+
+  const response = (await openmeetFetch(link, path)) as
+    | Record<string, unknown>
+    | Record<string, unknown>[];
   return Array.isArray(response)
     ? response
     : ((response as Record<string, unknown>).data as Record<

--- a/packages/app/src/routes/(app)/[space=didOrDomain]/calendar/+page.svelte
+++ b/packages/app/src/routes/(app)/[space=didOrDomain]/calendar/+page.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Button from "$lib/components/ui/button/Button.svelte";
-  import {
-    calendarLinkQuery,
-    calendarEventsQuery,
-  } from "$lib/queries/calendar.svelte";
+  import { calendarLinkQuery } from "$lib/queries/calendar.svelte";
   import { getAppState } from "$lib/queries";
   const app = getAppState();
   import { peer } from "$lib/workers";
@@ -17,11 +14,24 @@
     getStoredProfile,
     clearTokens,
   } from "$lib/services/openmeet";
+  import {
+    mapToCalEvent,
+    isRangeFresh as checkRangeFresh,
+    pruneExpiredRanges as pruneRanges,
+    type CalEvent,
+    type FetchedRange,
+  } from "$lib/services/calendar-utils";
 
   import LoadingLine from "$lib/components/helper/LoadingLine.svelte";
   import MainLayout from "$lib/components/layout/MainLayout.svelte";
   import SidebarMain from "$lib/components/sidebars/SpaceSidebar.svelte";
-  import { Calendar, DayGrid, TimeGrid, List, Interaction } from "@event-calendar/core";
+  import {
+    Calendar,
+    DayGrid,
+    TimeGrid,
+    List,
+    Interaction,
+  } from "@event-calendar/core";
 
   let spaceId = $derived(app.joinedSpace?.id);
   let linkQuery = $derived(spaceId ? calendarLinkQuery(spaceId) : undefined);
@@ -31,98 +41,92 @@
       : undefined,
   );
   let linkResolved = $derived(
-    linkQuery ? linkQuery.current.status !== "loading" : !spaceId
+    linkQuery ? linkQuery.current.status !== "loading" : !spaceId,
   );
   let noLink = $derived(linkResolved && !link);
 
-  let eventsQuery = $derived(spaceId ? calendarEventsQuery(spaceId) : undefined);
-  let events = $derived(
-    eventsQuery?.current.status === "success" ? eventsQuery.current.data : [],
-  );
-
-  // Normalize status to a CSS class: "cancelled" → "ec-status-cancelled"
-  // Works with both API values (published, cancelled) and lexicon tokens
-  // (community.lexicon.calendar.event#cancelled → cancelled)
-  function statusClass(status: string | undefined): string {
-    if (!status) return "ec-status-scheduled";
-    const normalized = status.includes("#") ? status.split("#").pop()! : status;
-    return `ec-status-${normalized.toLowerCase()}`;
-  }
-
-  // Map SQLite events to @event-calendar format
-  let calendarEvents = $derived(
-    events.map((e) => {
-      const cancelled = e.status?.toLowerCase() === "cancelled";
-      return {
-        id: e.slug,
-        title: cancelled ? `(Cancelled) ${e.name}` : e.name,
-        start: new Date(e.startDate),
-        end: new Date(e.endDate || e.startDate),
-        className: statusClass(e.status),
-        extendedProps: {
-          slug: e.slug,
-          location: e.location,
-          locationOnline: e.locationOnline,
-          status: e.status,
-        },
-      };
-    }),
-  );
-
   let selectedDate = $state(new Date());
 
-  let calRef: { getOption: (key: string) => unknown; setOption: (key: string, value: unknown) => void } | undefined = $state();
-
-  let calendarOptions = $derived({
-    view: "dayGridMonth",
-    date: selectedDate,
-    height: "100%",
-    editable: false,
-    eventStartEditable: false,
-    eventDurationEditable: false,
-    selectable: true,
-    events: calendarEvents,
-    headerToolbar: {
-      start: "prev,next today",
-      center: "title",
-      end: "dayGridMonth,timeGridDay,listMonth",
-    },
-    dateClick: (info: { date: Date; view: { type: string } }) => {
-      if (info.view.type === "dayGridMonth") {
-        selectedDate = info.date;
-        calRef?.setOption("view", "timeGridDay");
+  let calRef:
+    | {
+        getOption: (key: string) => unknown;
+        setOption: (key: string, value: unknown) => void;
       }
-    },
-    eventClick: (info: { event: { extendedProps: { slug: string } } }) => {
-      if (!link) return;
-      openOnOpenMeet(link, `/events/${info.event.extendedProps.slug}`, connected);
-    },
-  });
+    | undefined = $state();
 
   let connected = $state(isAuthenticated());
   let profile = $state(getStoredProfile());
-  let openmeetOptOut = $state(localStorage.getItem("openmeet:optOut") === "true");
+  let openmeetOptOut = $state(
+    localStorage.getItem("openmeet:optOut") === "true",
+  );
 
   type SyncState = "idle" | "syncing" | "done" | "error";
   let syncState = $state<SyncState>("idle");
   let errorMessage = $state("");
 
-  $effect(() => {
-    if (link && spaceId) {
-      if (!connected && app.did && !openmeetOptOut) {
-        connectToOpenMeet();
-      } else {
-        syncEvents();
-      }
-    }
-  });
+  // --- Data layer: SQLite (durable cache) + in-memory (session freshness) ---
 
-  async function syncEvents() {
-    if (!link || !spaceId) return;
-    syncState = "syncing";
+  let eventsMap = new Map<string, CalEvent>();
+  let calendarEvents = $state<CalEvent[]>([]);
+
+  // Track fetched ranges with timestamps for cache-first refresh (5 min TTL)
+  const STALE_TTL = 5 * 60 * 1000;
+  let fetchedRanges: FetchedRange[] = [];
+
+  // Generation counter to discard stale API responses on rapid navigation
+  let fetchGeneration = 0;
+
+  function flushEvents() {
+    calendarEvents = [...eventsMap.values()];
+  }
+
+  // Read cached events from SQLite for instant paint
+  async function loadFromSQLite(
+    startStr: string,
+    endStr: string,
+  ): Promise<void> {
+    if (!spaceId) return;
     try {
-      const apiEvents = await fetchGroupEvents(link);
+      const rows = (await peer.runQuery(sql`
+        select slug, name, start_date, end_date, location, location_online, status
+        from comp_calendar_event
+        where entity like ${spaceId + ":%"}
+          and start_date >= ${startStr}
+          and start_date < ${endStr}
+        order by start_date asc
+      `)) as unknown as Record<string, unknown>[];
 
+      if (rows.length > 0) {
+        for (const row of rows) {
+          eventsMap.set(row.slug as string, mapToCalEvent(row));
+        }
+        flushEvents();
+      }
+    } catch {
+      // SQLite read failed — not critical, API fetch will follow
+    }
+  }
+
+  // Replace SQLite events for a date range with fresh API data.
+  // Clears the range first so deleted events don't persist as ghosts.
+  async function writeToSQLite(
+    apiEvents: Record<string, unknown>[],
+    startStr: string,
+    endStr: string,
+  ): Promise<void> {
+    if (!spaceId) return;
+
+    await peer.runQuery(sql`BEGIN`);
+    try {
+      // Remove old events in this range
+      await peer.runQuery(sql`
+        delete from comp_calendar_event
+        where entity like ${spaceId + ":%"}
+          and start_date >= ${startStr}
+          and start_date < ${endStr}
+      `);
+
+      // Insert fresh data
       for (const e of apiEvents) {
         await peer.runQuery(sql`
           insert or replace into comp_calendar_event
@@ -140,13 +144,141 @@
           )
         `);
       }
+      await peer.runQuery(sql`COMMIT`);
+    } catch (e) {
+      await peer.runQuery(sql`ROLLBACK`).catch(() => {});
+      throw e;
+    }
+  }
+
+  // Stale-while-revalidate: read SQLite first (instant), then fetch API if stale
+  async function loadEventsForRange(
+    startStr: string,
+    endStr: string,
+  ): Promise<void> {
+    if (!link || !spaceId) return;
+    const startDate = new Date(startStr);
+    const endDate = new Date(endStr);
+    const startMs = startDate.getTime();
+    const endMs = endDate.getTime();
+
+    // 1. Instant paint from SQLite (even if stale)
+    await loadFromSQLite(startStr, endStr);
+
+    // 2. Skip API if range is fresh
+    if (checkRangeFresh(fetchedRanges, startMs, endMs, STALE_TTL)) return;
+
+    // 3. Fetch from API in background
+    const gen = ++fetchGeneration;
+    syncState = "syncing";
+    try {
+      const apiEvents = await fetchGroupEvents(link, startStr, endStr);
+
+      // Discard stale response if user navigated away during fetch
+      if (gen !== fetchGeneration) {
+        syncState = "idle";
+        return;
+      }
 
       syncState = "done";
+
+      // Replace in-memory events for this range with fresh API data
+      const freshSlugs = new Set(apiEvents.map((e) => e.slug as string));
+      for (const [slug, evt] of eventsMap) {
+        if (
+          evt.start >= startDate &&
+          evt.start < endDate &&
+          !freshSlugs.has(slug)
+        ) {
+          eventsMap.delete(slug);
+        }
+      }
+      for (const e of apiEvents) {
+        eventsMap.set(e.slug as string, mapToCalEvent(e));
+      }
+      fetchedRanges = pruneRanges(fetchedRanges, STALE_TTL);
+      fetchedRanges.push({ start: startMs, end: endMs, fetchedAt: Date.now() });
+      flushEvents();
+
+      // Persist to SQLite (fire and forget, log errors)
+      writeToSQLite(apiEvents, startStr, endStr).catch((e) => {
+        console.warn("Calendar SQLite cache write failed:", e);
+      });
     } catch (e) {
+      if (gen !== fetchGeneration) {
+        syncState = "idle";
+        return;
+      }
       syncState = "error";
       errorMessage = (e as Error).message;
     }
   }
+
+  // Invalidate all caches and reload via the calendar's current range
+  let lastLinkSlug: string | undefined;
+  let lastDatesSetRange: { start: string; end: string } | undefined;
+
+  function invalidateAndRefetch() {
+    fetchedRanges = [];
+    eventsMap = new Map();
+    flushEvents();
+    if (link && spaceId && lastDatesSetRange) {
+      loadEventsForRange(lastDatesSetRange.start, lastDatesSetRange.end);
+    }
+  }
+
+  // When link resolves (or changes), invalidate and reload.
+  // Subsequent view changes are handled solely by datesSet.
+  $effect(() => {
+    const slug = link?.groupSlug;
+    if (slug && slug !== lastLinkSlug) {
+      lastLinkSlug = slug;
+      invalidateAndRefetch();
+    }
+  });
+
+  // Auto-connect when link is available and user is not yet connected
+  $effect(() => {
+    if (link && spaceId && !connected && app.did && !openmeetOptOut) {
+      connectToOpenMeet();
+    }
+  });
+
+  let calendarOptions = $derived({
+    view: "dayGridMonth",
+    date: selectedDate,
+    height: "100%",
+    editable: false,
+    eventStartEditable: false,
+    eventDurationEditable: false,
+    selectable: true,
+    events: calendarEvents,
+    datesSet: (info: { startStr: string; endStr: string }) => {
+      lastDatesSetRange = { start: info.startStr, end: info.endStr };
+      if (link && spaceId && lastLinkSlug !== undefined) {
+        loadEventsForRange(info.startStr, info.endStr);
+      }
+    },
+    headerToolbar: {
+      start: "prev,next today",
+      center: "title",
+      end: "dayGridMonth,timeGridDay,listMonth",
+    },
+    dateClick: (info: { date: Date; view: { type: string } }) => {
+      if (info.view.type === "dayGridMonth") {
+        selectedDate = info.date;
+        calRef?.setOption("view", "timeGridDay");
+      }
+    },
+    eventClick: (info: { event: { extendedProps: { slug: string } } }) => {
+      if (!link) return;
+      openOnOpenMeet(
+        link,
+        `/events/${info.event.extendedProps.slug}`,
+        connected,
+      );
+    },
+  });
 
   async function connectToOpenMeet() {
     if (!link) return;
@@ -166,7 +298,8 @@
         }
       }
 
-      await syncEvents();
+      // Re-fetch events now that we're authenticated (may see private events)
+      invalidateAndRefetch();
     } catch (e) {
       errorMessage = (e as Error).message;
       syncState = "error";
@@ -179,8 +312,9 @@
     profile = null;
     openmeetOptOut = true;
     localStorage.setItem("openmeet:optOut", "true");
+    // Re-fetch to remove private events from view
+    invalidateAndRefetch();
   }
-
 </script>
 
 {#snippet sidebar()}
@@ -193,9 +327,7 @@
       <h2
         class="w-full py-4 text-base-900 dark:text-base-100 flex items-center gap-2"
       >
-        <div class="ml-2 font-bold grow text-center text-lg">
-          Events
-        </div>
+        <div class="ml-2 font-bold grow text-center text-lg">Events</div>
       </h2>
     </div>
   </div>
@@ -205,9 +337,7 @@
   <div class="p-4 h-full flex flex-col">
     {#if noLink}
       <div class="text-center py-12">
-        <h2
-          class="text-lg font-semibold text-base-900 dark:text-base-100 mb-2"
-        >
+        <h2 class="text-lg font-semibold text-base-900 dark:text-base-100 mb-2">
           No calendar connected
         </h2>
         <p class="text-sm text-base-600 dark:text-base-400 mb-4">
@@ -220,43 +350,56 @@
         {/if}
       </div>
     {:else}
-      {#if syncState === "syncing"}
-        <LoadingLine />
-      {/if}
       {#if syncState === "error"}
-        <div class="flex items-center gap-2 p-2 mb-2 rounded-lg bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 text-sm">
+        <div
+          class="flex items-center gap-2 p-2 mb-2 rounded-lg bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 text-sm"
+        >
           <span class="flex-1">{errorMessage}</span>
-          <Button onclick={syncEvents}>Retry</Button>
+          <Button onclick={invalidateAndRefetch}>Retry</Button>
         </div>
       {/if}
-      <div class="ec-wrapper flex-1 min-h-0 h-full">
-        <Calendar bind:this={calRef} plugins={[DayGrid, TimeGrid, List, Interaction]} options={calendarOptions} />
+      <div class="ec-wrapper flex-1 min-h-0 h-full relative">
+        {#if syncState === "syncing"}
+          <div class="absolute top-0 left-0 right-0 z-10">
+            <LoadingLine />
+          </div>
+        {/if}
+        <Calendar
+          bind:this={calRef}
+          plugins={[DayGrid, TimeGrid, List, Interaction]}
+          options={calendarOptions}
+        />
       </div>
 
       <!-- Footer: OpenMeet link + auth status -->
       {#if link}
-        <div class="mt-2 p-2 rounded-lg flex items-center justify-between text-sm text-base-400 dark:text-base-500">
-          <button class="ec-footer-link" onclick={() => link && openOnOpenMeet(link, `/groups/${link.groupSlug}`, connected)}>
+        <div
+          class="mt-2 p-2 rounded-lg flex items-center justify-between text-sm text-base-400 dark:text-base-500"
+        >
+          <button
+            class="ec-footer-link"
+            onclick={() =>
+              link &&
+              openOnOpenMeet(link, `/groups/${link.groupSlug}`, connected)}
+          >
             Manage events on OpenMeet ↗
           </button>
 
           {#if !connected}
             <span>
-              <button class="ec-footer-link" onclick={connectToOpenMeet}>Connect</button> to see private events
+              <button class="ec-footer-link" onclick={connectToOpenMeet}
+                >Connect</button
+              > to see private events
             </span>
           {:else if profile}
             <span class="flex items-center gap-1">
               {#if profile.avatar}
-                <img
-                  src={profile.avatar}
-                  alt=""
-                  class="w-5 h-5 rounded-full"
-                />
+                <img src={profile.avatar} alt="" class="w-5 h-5 rounded-full" />
               {/if}
-              {profile.displayName || profile.handle} · <button
-                class="ec-footer-link"
-                onclick={disconnect}
-              >Disconnect</button>
+              {profile.displayName || profile.handle} ·
+              <button class="ec-footer-link" onclick={disconnect}
+                >Disconnect</button
+              >
             </span>
           {/if}
         </div>


### PR DESCRIPTION
## Summary

Addresses feedback about calendar events being stale/out-of-date.

### Why replace LiveQuery?

The old approach used a `LiveQuery` on `comp_calendar_event` to reactively display events. But LiveQuery's reactivity added no value here — nothing else writes to that table, only our own code after fetching from the OpenMeet API. The result was:

- **No date filtering** — full-table scan of all events on every render
- **No freshness concept** — events fetched once stayed forever, even if changed on OpenMeet
- **Redundant re-scans** — each `insert or replace` triggered LiveQuery to re-run a query over data we just fetched

### What replaces it

A cache-first architecture that lazy-loads events by visible date range:

- **SQLite as durable cache**: OPFS-backed SQLite gives instant paint on revisit; if cached data is older than 5 minutes, a fresh API fetch runs and replaces it
- **Range-based loading**: `datesSet` callback fetches only the month/day the user is viewing, passes `startDate`/`endDate` query params to the API
- **Race condition handling**: generation counter discards stale API responses on rapid navigation

### Files changed

| File | Change |
|------|--------|
| `+page.svelte` | Cache-first loading with `loadEventsForRange`, `loadFromSQLite`, `writeToSQLite`, generation counter, loading overlay |
| `calendar-utils.ts` (new) | Pure functions extracted from component for testability |
| `calendar-utils.test.ts` (new) | 16 unit tests |
| `openmeet.ts` | Added optional `startDate`/`endDate` params to `fetchGroupEvents` |
| `calendar.svelte.ts` | Removed `CalendarEvent` interface and `calendarEventsQuery` (replaced by range-based loading) |

### Test plan

- [x] Unit tests pass (`pnpm test` — 16 tests in calendar-utils.test.ts)
- [x] Navigate between months — events load per-range, spinner overlays calendar
- [x] Connect/disconnect OpenMeet — events refresh correctly
- [x] Revisit a previously-viewed month — instant paint from cache, no spinner if < 5 min
- [x] Test in non-UTC timezone — date ranges match calendar boundaries