### PR TITLE
fix: enact login form standardization

### DIFF
--- a/packages/app/src/lib/components/user/LoginForm.svelte
+++ b/packages/app/src/lib/components/user/LoginForm.svelte
@@ -239,10 +239,16 @@
           name="handle"
           id="atproto-handle"
           autocomplete="username"
+          list="past-handles"
           placeholder="name.bsky.social"
           class="w-full text-sm py-2 px-3 rounded-lg"
           bind:value={handle.value}
         />
+        {#if lastLogin?.handle}
+          <datalist id="past-handles">
+            <option value={lastLogin.handle} />
+          </datalist>
+        {/if}
         {#if error}
           <p
             class="text-red-600 dark:text-red-400 text-xs font-medium w-full pt-2"

--- a/packages/app/src/lib/components/user/LoginForm.svelte
+++ b/packages/app/src/lib/components/user/LoginForm.svelte
@@ -236,8 +236,9 @@
         <Input
           bind:ref={input}
           type="text"
-          name="atproto-handle"
+          name="handle"
           id="atproto-handle"
+          autocomplete="username"
           placeholder="name.bsky.social"
           class="w-full text-sm py-2 px-3 rounded-lg"
           bind:value={handle.value}
@@ -273,7 +274,7 @@
       <div class="flex items-center relative h-9">
         <Input
           class="shrink grow min-w-0 flex justify-between absolute inset-0 w-full text-sm py-2 px-3 rounded-lg"
-          type="username"
+          type="text"
           bind:value={handle.value}
           id="atproto-reg-handle"
           placeholder="lovelyhandle"
@@ -297,6 +298,7 @@
       >
       <Input
         type="email"
+        autocomplete="email"
         bind:value={email}
         placeholder="your@email.com"
         id="atproto-reg-email"


### PR DESCRIPTION
## overview:

this PR adds:
 - 2 attributes to the login username input: `name="handle"` and `autocomplete="username"` in order to comply with a standard being set across the AT Protocol
 -  updates the `type` attribute in the registration username input from `"username" to `"text"` to comply with valid HTML [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/text) 
 -  adds  `autocomplete="email"` attribute to registration email to help users sign up quicker

## context
this PR addresses issue #601 Username autofill

this PR introduces login form standardization as described in [discourse issue #644](https://discourse.atprotocol.community/t/a-plea-a-convention-for-input-name-handle/644)


> [!NOTE]
> the approach in commit  9ff7caf803138defbccdace90d9440ab90c55479 didnt change any UX as the prior attribute `name="atproto-handle"` was working for browser autofill and this is more a "standardization" 

> [!IMPORTANT]
>for mobile the "standardization" approrach alone doesn't solve for mobile due to the way oauth redirects and doesnt surface the success to the initial login screen. Roomy is uniquely positioned to fix this issue in mobile bc of the localStorage `last-login` field. we can leverage that to render a datalist in mobile view. i committed that code on it's own (141092bf69906ffd476694367a783ea0ca71d0e5) and it can easily be removed if deemed "out of scope" for first issue

## screenshots
### if we were to leverage the localStorage key to create a datalist on mobile:
iOS
<img width="461" height="962" alt="Screenshot 2026-03-31 at 1 32 25 PM" src="https://github.com/user-attachments/assets/ef82999c-dda3-4ae0-af21-0c3df3069f39" />
Android
<img width="423" height="858" alt="Screenshot 2026-03-31 at 1 22 25 PM" src="https://github.com/user-attachments/assets/d6e17a32-6ef1-472a-8179-661c066139df" />


