### PR TITLE
fix(appserver): don't block updateSeen on membership hydration

### DIFF
--- a/packages/appserver/src/db/schema.sql
+++ b/packages/appserver/src/db/schema.sql
@@ -34,6 +34,14 @@ create index if not exists idx_entities_sort_idx on entities(sort_idx);
 -- with a reverse sort order to get only the latest entities.
 create index if not exists idx_entities_room on entities (room, id desc);
 
+-- Room-scoped sort_idx lookups: `max(sort_idx) where room = ?` (updateSeen
+-- watermark) and `count(*) where room = ? and sort_idx > ?` (unread count).
+-- Without this, idx_entities_room orders by id (not sort_idx), so those
+-- aggregates scan every entity in the room. Purely additive/idempotent —
+-- created on existing DBs at next boot, so it does NOT need a SCHEMA_VERSION
+-- bump (a bump would force a full re-materialisation of every space).
+create index if not exists idx_entities_room_sort on entities (room, sort_idx);
+
 create table if not exists edges (
     head text not null, -- did or ulid
     tail text not null, -- did or ulid

--- a/packages/appserver/src/handlers/space.roomy.room.updateSeen.test.ts
+++ b/packages/appserver/src/handlers/space.roomy.room.updateSeen.test.ts
@@ -1,0 +1,135 @@
+/**
+ * updateSeen handler: the read-position write must NOT depend on a live
+ * materializer for the room's space. Hydration is kicked off in the background
+ * (fire-and-forget); the handler reads the already-on-disk materialisation and
+ * writes the watermark synchronously. These tests seed a room + messages, then
+ * call the handler with NO materializer registered for the room's space and
+ * assert the read_positions row is written correctly.
+ */
+
+import { beforeEach, afterEach, describe, expect, test } from "bun:test";
+import {
+  StreamDid,
+  UserDid,
+  newUlid,
+  type EventCallback,
+  type StreamIndex,
+} from "@roomy-space/sdk";
+
+import { closeDb, openDb } from "../db/db.ts";
+import {
+  attachInMemoryReadState,
+  closeReadStateDb,
+} from "../db/readStateDb.ts";
+import {
+  _resetMaterializerRegistry,
+  getOrCreateMaterializer,
+} from "../materialization/registry.ts";
+import type { ConnectedSpaceLike } from "../materialization/SpaceMaterializer.ts";
+import { _resetHydrationInflight } from "../hydration/userHydration.ts";
+import { updateSeenHandler } from "./space.roomy.room.updateSeen.ts";
+
+const USER = UserDid.assert("did:plc:seen-user");
+const PERSONAL = StreamDid.assert("did:web:personal.example");
+const SPACE = StreamDid.assert("did:web:space.example");
+
+/** Fake space whose backfill resolves immediately (no network). */
+function instantSpace(streamDid: StreamDid): ConnectedSpaceLike {
+  return {
+    streamDid,
+    subscribe: ((_cb: EventCallback, _start: StreamIndex) =>
+      Promise.resolve(newUlid())) as ConnectedSpaceLike["subscribe"],
+    unsubscribe: (() => Promise.resolve()) as ConnectedSpaceLike["unsubscribe"],
+  };
+}
+
+interface ReadPositionRow {
+  seen_up_to: string;
+  unread_count: number;
+}
+
+function readPosition(roomId: string): ReadPositionRow | null {
+  return openDb()
+    .query<
+      ReadPositionRow,
+      [string, string]
+    >(
+      "select seen_up_to, unread_count from readstate.read_positions where user_did = ? and room_id = ?",
+    )
+    .get(USER, roomId);
+}
+
+let roomId: string;
+let msgA: string;
+let msgB: string;
+
+beforeEach(async () => {
+  closeDb();
+  closeReadStateDb();
+  _resetMaterializerRegistry();
+  _resetHydrationInflight();
+
+  // In-memory singleton so the handler's internal openDb() sees this DB.
+  const db = openDb({ path: ":memory:" });
+  attachInMemoryReadState(db);
+
+  roomId = newUlid();
+  msgA = newUlid();
+  msgB = newUlid();
+
+  // Room lives in SPACE; two messages with sort_idx "a" < "b".
+  db.run("insert into entities (id, stream_id) values (?, ?)", [SPACE, SPACE]);
+  db.run("insert into entities (id, stream_id) values (?, ?)", [roomId, SPACE]);
+  db.run(
+    "insert into entities (id, stream_id, room, sort_idx) values (?, ?, ?, ?)",
+    [msgA, SPACE, roomId, "a"],
+  );
+  db.run(
+    "insert into entities (id, stream_id, room, sort_idx) values (?, ?, ?, ?)",
+    [msgB, SPACE, roomId, "b"],
+  );
+
+  // Make the background hydration hermetic: seed the personal-stream cache and
+  // pre-warm ONLY the personal materializer with an instant fake. The room's
+  // space (SPACE) intentionally has NO materializer registered.
+  db.run(
+    "insert into comp_user_personal_stream (user_did, personal_stream_did, resolved_at) values (?, ?, ?)",
+    [USER, PERSONAL, 0],
+  );
+  await getOrCreateMaterializer(PERSONAL, {
+    db,
+    getConnectedSpace: () => Promise.resolve(instantSpace(PERSONAL)),
+  });
+});
+
+afterEach(() => {
+  closeDb();
+  closeReadStateDb();
+  _resetMaterializerRegistry();
+  _resetHydrationInflight();
+});
+
+describe("updateSeen", () => {
+  test("no seenUpTo → marks read up to latest message, unread 0 (no space materializer)", async () => {
+    await updateSeenHandler({}, { did: USER }, { roomId });
+
+    const row = readPosition(roomId);
+    expect(row).not.toBeNull();
+    expect(row?.seen_up_to).toBe("b"); // max(sort_idx)
+    expect(row?.unread_count).toBe(0);
+  });
+
+  test("explicit seenUpTo → watermark at that message, unread counts the rest", async () => {
+    await updateSeenHandler({}, { did: USER }, { roomId, seenUpTo: msgA });
+
+    const row = readPosition(roomId);
+    expect(row?.seen_up_to).toBe("a"); // msgA's sort_idx
+    expect(row?.unread_count).toBe(1); // msgB is after the watermark
+  });
+
+  test("unknown room still 404s after the hydration fallback", async () => {
+    await expect(
+      updateSeenHandler({}, { did: USER }, { roomId: newUlid() }),
+    ).rejects.toThrow(/Room not found/);
+  });
+});

--- a/packages/appserver/src/handlers/space.roomy.room.updateSeen.ts
+++ b/packages/appserver/src/handlers/space.roomy.room.updateSeen.ts
@@ -48,10 +48,31 @@ export const updateSeenHandler: ProcedureHandler<UpdateSeenBody, void> = async (
     );
   }
 
-  await hydrateUserMembership(userDid);
+  // Warm this user's space materializers in the background. We deliberately do
+  // NOT await: recording a read position only needs the on-disk materialisation
+  // (which persists across restarts), so blocking here on a cold Leaf
+  // re-subscribe is what made the first `updateSeen` for a space slow. The reads
+  // below run against whatever is already materialised; a mid-backfill space
+  // just yields a slightly stale watermark that self-corrects as live messages
+  // arrive.
+  void hydrateUserMembership(userDid).catch(() => {});
 
   const db = openDb();
-  const access = requireRoomRead(db, roomId, userDid);
+  let access: ReturnType<typeof requireRoomRead>;
+  try {
+    access = requireRoomRead(db, roomId, userDid);
+  } catch (err) {
+    // The room may not be materialised yet on a cold (lazy) space if no read
+    // handler ran first. Fall back to awaiting hydration once, then retry —
+    // hydrateUserMembership dedups in-flight, so this shares the background
+    // call kicked off above rather than doing the work twice.
+    if (err instanceof XrpcError && err.status === 404) {
+      await hydrateUserMembership(userDid);
+      access = requireRoomRead(db, roomId, userDid);
+    } else {
+      throw err;
+    }
+  }
 
   let seenUpTo: string;
   let unreadCount: number;


### PR DESCRIPTION
I was trying to figure out why switching channels sometimes felt so slow and I think this might help? My local dev is kinda borked at the moment so was only able to partially verify it. If this seems like the right approach please verify on a setup that actually works before merging.

Here's claude's description of the fix:

updateSeen awaited hydrateUserMembership before doing its work. On a cold space that call synchronously establishes (or re-establishes) the Leaf subscription for every joined space, so the first channel-open in a space -- or the first open after a redeploy, which clears the in-memory materializer registry -- paid seconds of latency just to write a read watermark.

Recording a read position only needs the on-disk materialisation, which persists across restarts and never requires a live Leaf subscription. So hydration is now fire-and-forget (it still warms the space in the background for the follow-up getMessages/getMetadata reads). A 404 fallback awaits hydration once and retries for the cold, lazy-mode first-open case where the room isn't materialised on disk yet; hydrateUserMembership dedups in-flight so this shares the background call.

Also add idx_entities_room_sort(room, sort_idx). updateSeen's `max(sort_idx) where room = ?` and unread `count(*) where room = ? and sort_idx > ?` previously scanned every entity in the room (idx_entities_room is ordered by id); they now use a covering index. Purely additive/idempotent, so no SCHEMA_VERSION bump (a bump would force a full re-materialisation).

Adds a handler test proving the read position is written with no materializer registered for the room's space.