### PR TITLE
fix: drop hardcoded /workspace pnpm storeDir

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,13 +9,12 @@ packages:
   - packages/tsconfig
 
 onlyBuiltDependencies:
-  - '@swc/core'
-  - '@tailwindcss/oxide'
+  - "@swc/core"
+  - "@tailwindcss/oxide"
   - cbor-extract
   - core-js
   - esbuild
   - node
 
 patchedDependencies:
-  '@discordeno/gateway': patches/@discordeno__gateway.patch
-storeDir: /workspace/.pnpm-store
+  "@discordeno/gateway": patches/@discordeno__gateway.patch


### PR DESCRIPTION
pnpm-workspace.yaml pinned `storeDir: /workspace/.pnpm-store`, a cloud-container path. `pnpm install` fails on any host where that path isn't writable -- macOS/Linux dev machines (can't mkdir under /) and even this repo's own .devcontainer (workdir /code, non-root user). pnpm 10 also gives pnpm-workspace.yaml precedence over env vars and .npmrc, so it can't be overridden locally either.

Removing the line lets pnpm use its per-user default store (works in all those environments) and lets anyone who wants a custom store set it per environment via env var / CLI flag.