### PR TITLE
fix(app-lite): route XRPC to the local appserver in dev

### DIFF
--- a/packages/app-lite/src/lib/auth.svelte.ts
+++ b/packages/app-lite/src/lib/auth.svelte.ts
@@ -90,7 +90,13 @@ export async function init() {
 
       // Set up direct XRPC transport with service auth
       serviceAuth = new ServiceAuthClient(result.agent);
-      const appserverUrl = await resolveAppserverHttpOrigin(CONFIG.appserverDid);
+      // Local dev: when an HTTP origin override is set (derived from
+      // VITE_APPSERVER_WS_ORIGIN), send XRPC to the local appserver instead of
+      // resolving the DID to production. Keeps queries/procedures and the sync
+      // WS pointed at the same local server.
+      const appserverUrl =
+        CONFIG.appserverHttpOrigin ??
+        (await resolveAppserverHttpOrigin(CONFIG.appserverDid));
       setAppserverOrigin(appserverUrl);
       directXrpc = new DirectXrpcClient(
         appserverUrl,

--- a/packages/app-lite/src/lib/config.ts
+++ b/packages/app-lite/src/lib/config.ts
@@ -30,6 +30,17 @@ export const CONFIG = {
    * Useful for local development: VITE_APPSERVER_WS_ORIGIN=ws://127.0.0.1:8080
    */
   appserverWsOrigin: import.meta.env.VITE_APPSERVER_WS_ORIGIN || null,
+  /**
+   * HTTP origin for direct XRPC calls (getMessages, updateSeen, …). In local
+   * dev we derive it from the WS-origin override so a single
+   * VITE_APPSERVER_WS_ORIGIN points BOTH the sync WebSocket and the XRPC HTTP
+   * client at the local appserver. When unset, the HTTP origin is resolved
+   * from the appserver DID (i.e. production).
+   */
+  appserverHttpOrigin:
+    (import.meta.env.VITE_APPSERVER_WS_ORIGIN || "")
+      .replace(/^ws(s?):\/\//, "http$1://")
+      .replace(/\/+$/, "") || null,
   port: Number(import.meta.env.VITE_PORT) || 5180,
   usePublicClient: import.meta.env.VITE_OAUTH_PUBLIC_CLIENT === "true",
   profileSpaceNsid:


### PR DESCRIPTION
VITE_APPSERVER_WS_ORIGIN only redirected the sync WebSocket. The DirectXrpcClient still resolved its HTTP origin from the appserver DID, so every query and procedure (getMessages, updateSeen, createSpace, ...) went to the resolved (production) appserver even in local dev -- making it impossible to exercise a locally-running appserver from the app.

Derive appserverHttpOrigin from the same VITE_APPSERVER_WS_ORIGIN override (ws -> http) so a single env var points both the sync WS and the XRPC HTTP client at the local appserver. Falls back to DID resolution when unset, so production is unaffected.