### PR TITLE
Fix Freezing of UI When Multiple of the Same Channel Get Added to the Sidebar

### DIFF
--- a/packages/app-lite/src/lib/components/sidebar/SpaceSidebar.svelte
+++ b/packages/app-lite/src/lib/components/sidebar/SpaceSidebar.svelte
@@ -221,7 +221,9 @@ import RoomyMark from "$lib/components/RoomyMark.svelte";
 
   let draftOrder = $state<DraftOrder | null>(null);
 
-  const categories = $derived(meta?.sidebar.categories ?? []);
+  const categories = $derived(meta?.sidebar.categories?.map(
+      cat => [new Map(cat.channels?.map(ch => [ch.id, ch]) ?? []).values]
+      ?? []));
 
   let categoryMap = $state(new Map<string, SidebarCategory>());
 

--- a/packages/app-lite/src/lib/components/sidebar/SpaceSidebar.svelte
+++ b/packages/app-lite/src/lib/components/sidebar/SpaceSidebar.svelte
@@ -222,7 +222,7 @@ import RoomyMark from "$lib/components/RoomyMark.svelte";
   let draftOrder = $state<DraftOrder | null>(null);
 
   const categories = $derived(meta?.sidebar.categories?.map(
-      cat => [new Map(cat.channels?.map(ch => [ch.id, ch]) ?? []).values]
+      cat => ({...cat, channels: [new Map(cat.channels?.map(ch => [ch.id, ch]) ?? []).values]})
       ?? []));
 
   let categoryMap = $state(new Map<string, SidebarCategory>());


### PR DESCRIPTION
I submitted this bug report in the Roomy Space:
> I created a bunch of channels in a new space and then wanted to reorganize them under categories. I entered sidebar edit mode and dragged a channel down to a different category, which already had several channels in it. I decided I didn't want the channel I had just dragged down at the bottom of the category list, so I tried to drag it up in the same category (drag-and-dropped from category X onto the same category X in a different position). The channel looked like it was duplicated (2 identical channels showing under category X). I thought it was just a frontend bug, so I tried to save (Done button) the layout and refresh the page. I think it actually did save 2 duplicate channel entries though, because now my entire space won't load with an each_key_duplicate error (see attached console error)

The error is `Uncaught Error: https://svelte.dev/e/each_key_duplicate` and is occurring in `SpaceSidebar.svelte` in this snippet:
```
<div class="flex flex-col w-full min-h-4">
          {#each displayCategories as category (category.id ?? category.name)}
            {#if category.name}
              <div class="px-2 pt-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-base-400 dark:text-base-500">
                {category.name}
              </div>
            {/if}
            {#each category.channels as channel (channel.id)} // Error occurs here
              {@render channelItem(channel)}
            {/each}
          {/each}
        </div>
```

I inspected the response payload and sure enough, there's a duplicate channel entry in one of my categories.

This PR doesn't fix the root cause of duplicate channels being written to a category, but I think the fact that my entire Space is currently unusable (literally just hangs as soon as you open the Space, I can't even navigate to Settings) merits the app handling this gracefully.

Since I don't see any guaranteed order (at least with regard to the duplicates), this change can be assumed to arbitrarily pick one of the duplicate channels to win and be "the channel" for a duplicate channel ID. I'm assuming the channel ID is used for everything to do with the channel (reads, writes, metadata), so I don't think this will cause any problems? I.e. any writes to duplicate A will be read back from duplicate B since channel ID is used for everything anyway.

This is my first PR to this group so let me know if I'm missing anything!