### PR TITLE
feat: native app oauth roundtrip

### DIFF
--- a/packages/app-lite/src-tauri/Cargo.lock
+++ b/packages/app-lite/src-tauri/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-http",
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-os",
@@ -494,6 +495,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,8 +562,37 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -577,7 +618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -590,7 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -599,6 +640,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -715,6 +765,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dbus"
@@ -844,6 +900,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dom_query"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +993,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1322,8 +1396,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1345,8 +1421,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1498,6 +1577,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1696,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1606,6 +1705,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1626,9 +1741,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2019,6 +2136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,6 +2155,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2723,12 +2852,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2751,6 +2952,32 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2829,6 +3056,49 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2859,6 +3129,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2900,10 +3184,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3096,6 +3421,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,7 +3502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3304,6 +3641,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,6 +3719,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,7 +3760,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -3475,7 +3839,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3593,6 +3957,54 @@ dependencies = [
  "url",
  "windows-registry",
  "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.19",
+ "toml 1.1.3+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-http"
+version = "2.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "data-url",
+ "http",
+ "regex",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.19",
+ "tokio",
+ "url",
+ "urlpattern",
 ]
 
 [[package]]
@@ -3912,7 +4324,29 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3924,6 +4358,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4229,6 +4664,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4416,6 +4857,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4469,6 +4920,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4710,6 +5170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5158,6 +5627,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/packages/app-lite/src-tauri/Cargo.toml
+++ b/packages/app-lite/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "2.0.12"
 tauri-plugin-deep-link = "2.4.9"
 tauri-plugin-opener = "2.5.4"
 tauri-plugin-os = "2.3.2"
+tauri-plugin-http = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = {version = "2", features = ["deep-link"] }

--- a/packages/app-lite/src-tauri/capabilities/default.json
+++ b/packages/app-lite/src-tauri/capabilities/default.json
@@ -16,6 +16,14 @@
       ]
     },
     "os:default",
-    "log:default"
+    "log:default",
+    {"identifier": "opener:allow-open-path",
+    "allow": [
+      {"url": "https://*" }
+    ]},
+    {
+      "identifier": "http:default",
+      "allow": [{"url": "https://roomy.space/*"}]
+    }
   ]
 }

--- a/packages/app-lite/src-tauri/src/lib.rs
+++ b/packages/app-lite/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub fn run() {
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_http::init())
         .setup(|app| {
             // runtime deep_link registration
             #[cfg(any(target_os = "linux", windows))]

--- a/packages/app-lite/src-tauri/tauri.conf.json
+++ b/packages/app-lite/src-tauri/tauri.conf.json
@@ -8,6 +8,7 @@
     "devUrl": "http://localhost:5180"
   },
   "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
         "title": "Roomy",
@@ -45,7 +46,6 @@
         },
         {
           "scheme": ["https"],
-          "pathPrefix": ["/oauth/callback"],
           "host": "space.roomy",
           "appLink": true
         }

--- a/packages/app-lite/src-tauri/tauri.conf.json
+++ b/packages/app-lite/src-tauri/tauri.conf.json
@@ -40,13 +40,13 @@
     "deep-link": {
       "mobile": [
         {
-          "scheme": ["space.roomy"],
-          "host": "space.roomy",
+          "scheme": ["space.roomy", "roomy"],
           "appLink": false
         },
         {
           "scheme": ["https"],
-          "host": "space.roomy",
+          "host": "roomy.space",
+          "pathPrefix": ["/"],
           "appLink": true
         }
       ],

--- a/packages/app-lite/src/lib/auth.svelte.ts
+++ b/packages/app-lite/src/lib/auth.svelte.ts
@@ -186,12 +186,23 @@ export async function login(handle: string) {
   // Remember the page the user was on so `init()` can send them back here
   // after the PDS redirects to the fixed OAuth redirect URI (the homepage).
   const returnUrl = currentReturnUrl();
-  await sdkLogin(CONFIG.appserverDid, handle, {
+  const result = await sdkLogin(CONFIG.appserverDid, handle, {
     port: CONFIG.port,
     scope: OAUTH_SCOPE,
     usePublicClient: CONFIG.usePublicClient,
     state: returnUrl,
   });
+
+  if (result) {
+    session = result.session;
+    agent = result.agent;
+    await setupDirectXrpc(result.agent);
+    authenticated = true;
+    const target = safeReturnUrl(result.state) ?? returnUrl;
+    if (target && target !== currentReturnUrl()) {
+      goto(target, { replaceState: true });
+    }
+  }
 }
 
 /**

--- a/packages/app-lite/src/routes/+layout.svelte
+++ b/packages/app-lite/src/routes/+layout.svelte
@@ -113,6 +113,20 @@
       return () => untrack(() => stopSync());
     }
   });
+
+  // Queries mount while the login modal is up (page content renders beneath
+  // it) and call `px()`, which throws "Not authenticated" until `directXrpc`
+  // exists. Those errors are cached with `staleTime: Infinity`, and no page
+  // reload occurs on an in-place Tauri login, so they'd persist until refresh.
+  // On the unauthenticated → authenticated transition, invalidate everything
+  // so active queries refetch with the fresh session.
+  let wasAuthenticated = false;
+  $effect(() => {
+    if (auth.authenticated && !wasAuthenticated) {
+      queryClient.invalidateQueries();
+    }
+    wasAuthenticated = auth.authenticated;
+  });
 </script>
 
 <QueryClientProvider client={queryClient}>

--- a/packages/sdk/src/browser/oauth.ts
+++ b/packages/sdk/src/browser/oauth.ts
@@ -17,6 +17,26 @@ import {
 import { Agent } from "@atproto/api";
 import type { OAuthSession } from "@atproto/oauth-client-browser";
 
+// Declares necessary parts of tauri JS API exposed through `window.__TAURI__`. 
+// (available when `withGlobalTauri` is enabled in config.tauri.json)
+// without a dependency on @tauri-apps/api
+// Tauri apps gate access on the runtime check `'__TAURI__' in window`.
+declare global {
+  interface Window {
+    __TAURI__?: {
+      opener: {
+        openUrl(url: string | URL): Promise<void>;
+      };
+      deepLink: {
+        onOpenUrl(handler: (urls: string[]) => void): Promise<() => void>;
+      };
+      http: {
+        fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>
+      }
+    };
+  }
+}
+
 // ── Config ────────────────────────────────────────────────────────────────
 
 const HANDLE_RESOLVER = "https://bsky.social";
@@ -226,12 +246,21 @@ export async function createOAuthClient(
 ): Promise<BrowserOAuthClient> {
   const scope = opts.scope ?? buildScope(appserverDid);
 
+  const tauri = window.__TAURI__
   // Production: fetch public client metadata deployed alongside the static build
   if (opts.usePublicClient) {
     const resp = await fetch("/oauth-client-metadata.json", {
       headers: [["accept", "application/json"]],
     });
     const clientMetadata = await resp.json();
+    return new BrowserOAuthClient({
+      clientMetadata,
+      handleResolver: HANDLE_RESOLVER,
+      responseMode: "query",
+    });
+  } else if (tauri) {
+    const req = await tauri.http.fetch("https://roomy.space/oauth-client-native.json")
+    const clientMetadata = await req.json()
     return new BrowserOAuthClient({
       clientMetadata,
       handleResolver: HANDLE_RESOLVER,
@@ -302,6 +331,11 @@ export interface InitSessionOptions {
    * signing in and redirect back to it after the PDS callback.
    */
   state?: string;
+  /**
+   * How long the login flow should stay pending before `login()`
+   * aborts (user abandoned auth). Defaults to 10 minutes,
+   */
+  loginTimeoutMs?: number;
 }
 
 /**
@@ -311,12 +345,34 @@ export interface InitSessionOptions {
  * is the OAuth `state` value round-tripped through the PDS (present only
  * when this call processed an OAuth callback, not a plain session restore).
  */
+export type LoginResult = { session: OAuthSession; agent: Agent; state?: string | null; }
+
 export async function initSession(
   appserverDid: string,
   opts: InitSessionOptions = {},
-): Promise<{ session: OAuthSession; agent: Agent; state?: string | null } | null> {
+): Promise<LoginResult | null> {
   const client = await createOAuthClient(appserverDid, opts);
-  const result = await client.init();
+  let result: {
+    session: OAuthSession;
+    state?: never;
+  } | {
+    session: OAuthSession;
+    state: string | null;
+  } | undefined
+
+  // Tauri / native custom-scheme callbacks can't be auto-detected by `client.init()`:
+  // `findRedirectUrl()` compares HTTP origins against the
+  // registered redirect URIs, and a `space.roomy:/…` scheme never matches the
+  // webview origin (`tauri://localhost`). 
+  if ('__TAURI__' in window) {
+    const params = new URLSearchParams(location.search);
+    if (params.has('state') && (params.has('code') || params.has('error'))) {
+      result = await client.initCallback(params, client.clientMetadata.redirect_uris[0]);
+    }
+  } else {
+    result = await client.init();
+  }
+
   if (result?.session) {
     return {
       session: result.session,
@@ -331,19 +387,82 @@ export async function initSession(
 }
 
 /**
- * Initiate an OAuth sign-in flow. This will redirect the browser to the
- * PDS authorization page; the promise does **not** resolve in the current
- * page context (the browser navigates away).
+ * Initiate an OAuth sign-in flow.
+ *
+ * Web: redirects the browser to the PDS authorization page; the promise does
+ * **not** resolve in the current page context (the browser navigates away)
+ * and the returned value is never reached.
+ *
+ * Tauri: opens the PDS in the system browser, then **blocks** until the
+ * deep-link redirect (`space.roomy:/?state=…&code=…`) arrives and processes
+ * the callback in place. Returns `LoginResult` on success and throws on error/denial
  */
 export async function login(
   appserverDid: string,
   handle: string,
   opts: InitSessionOptions = {},
-): Promise<void> {
+): Promise<void | LoginResult> {
   const client = await createOAuthClient(appserverDid, opts);
+
+  const tauri = window.__TAURI__;
+  if (tauri) {
+    // opener IPC promise or the deep-link listener could in theory never settle.
+    // Race the whole Tauri flow against a timeout so an abandoned login ALWAYS resolves,
+    // letting the caller revert its loading state and surface the expiry. 
+    const timeoutMs = opts.loginTimeoutMs ?? 10 * 60_000;
+    return await Promise.race([
+      tauriLogin(client, handle, opts, tauri),
+      new Promise<void>((_, reject) => setTimeout(() => reject(new Error('Auth request has expired')), timeoutMs)),
+    ])
+  }
+
   // Forward `state` so the app can round-trip a return URL through the PDS.
   // The value comes back unchanged via `initSession()`'s `state` field.
   await client.signIn(handle, opts.state ? { state: opts.state } : undefined);
+}
+
+async function tauriLogin(
+  client: BrowserOAuthClient,
+  handle: string,
+  opts: InitSessionOptions,
+  tauri: NonNullable<Window["__TAURI__"]>,
+): Promise<LoginResult> {
+  const url = await client.authorize(handle, opts.state ? { state: opts.state } : undefined);
+
+  // Fire-and-forget. Promise may never settle on some platforms
+  tauri.opener.openUrl(url);
+
+
+  // Wait for the next deep-link event targeting this app. Resolves with the
+  // first URL (e.g. `space.roomy:/?state=…&code=…`) or `null` on timeout.
+  // The listener is removed on the first event (or after the timeout)
+  const deepUrl = await new Promise<string>((resolve, reject) => {
+    let unlisten: (() => void) | undefined;
+    tauri.deepLink
+      .onOpenUrl((urls) => {
+        unlisten?.();
+        const url = urls[0]
+        if (!url) {
+          reject(new Error('Error while opening url'))
+          return
+        }
+        resolve(url)
+      })
+      .then((unlistenFn) => {
+        unlisten = unlistenFn;
+      })
+      .catch(reject)
+  });
+
+  // initCallback throws on error in query params 
+  const params = new URLSearchParams(new URL(deepUrl).search);
+  const result = await client.initCallback(params, client.clientMetadata.redirect_uris[0]);
+  if (result.session) return {
+    session: result.session,
+    agent: new Agent(result.session as any),
+    state: result.state,
+  };
+  throw new Error('Invalid session result')
 }
 
 /**


### PR DESCRIPTION
Makes changes to sdk and app lite to handle oauth redirect in tauri native apps. Instead of opening pds oauth page within the app, where it is not possible for users to verify the url, this change opens the oauth link in the user's default browser then redirects back to the app to where `state|error` is read from query params.
  
adds http plugin (reqwest wrapper) to tauri to fetch live atproto client metadata
fixes android AppLink `host` to point at http url

tested and working on linux and android 14

Depends on #648