### PR TITLE
message forwarding

### DIFF
--- a/packages/app-lite/src/lib/components/chat/ChatArea.svelte
+++ b/packages/app-lite/src/lib/components/chat/ChatArea.svelte
@@ -18,6 +18,7 @@
   import { px } from "$lib/auth.svelte";
   import { scrollPositionState } from "./scroll-position.svelte";
   import { prefetchInternalLinkSummaries } from "./prefetch-link-summaries";
+  import ForwardMessageModal from "./ForwardMessageModal.svelte";
 
   const { queryKey } = cache;
 
@@ -64,6 +65,15 @@
   function openDeleteConfirm(message: Message) {
     deleteMessageTarget = message;
     isDeleteConfirmOpen = true;
+  }
+
+  // Forward modal state — lifted here so one modal serves every message.
+  let forwardMessage = $state<Message | null>(null);
+  let isForwardModalOpen = $state(false);
+
+  function openForward(message: Message) {
+    forwardMessage = message;
+    isForwardModalOpen = true;
   }
 
   function openMobileMenu(message: Message) {
@@ -416,6 +426,7 @@
                       onCancelEdit={() => (editingMessageId = undefined)}
                       onOpenMobileMenu={openMobileMenu}
                       onRequestDelete={openDeleteConfirm}
+                      onForward={openForward}
                       mergeWithPrevious={message.mergeWithPrevious}
                     />
                   {/if}
@@ -455,6 +466,7 @@
       isMobileDrawerOpen = false;
       openDeleteConfirm(mobileMenuMessage);
     }}
+    onForward={openForward}
   />
 
   <DeleteMessageDialog
@@ -470,4 +482,13 @@
       await deleteMessage(spaceId, roomId, deleteMessageTarget.id);
     }}
   />
+
+  {#if forwardMessage}
+    <ForwardMessageModal
+      bind:open={isForwardModalOpen}
+      {spaceId}
+      fromRoomId={roomId}
+      messageId={forwardMessage.id}
+    />
+  {/if}
 </div>

--- a/packages/app-lite/src/lib/components/chat/ChatMessage.svelte
+++ b/packages/app-lite/src/lib/components/chat/ChatMessage.svelte
@@ -29,6 +29,7 @@
     onOpenMobileMenu: (message: Message) => void;
     /** Requests the delete confirmation for this message (raised to ChatArea). */
     onRequestDelete: (message: Message) => void;
+    onForward: (message: Message) => void;
     mergeWithPrevious?: boolean;
   };
 
@@ -43,6 +44,7 @@
     onCancelEdit,
     onOpenMobileMenu,
     onRequestDelete,
+    onForward,
     mergeWithPrevious = false,
   }: Props = $props();
 
@@ -208,6 +210,7 @@
           bind:keepToolbarOpen
           {onStartEdit}
           onRequestDelete={() => onRequestDelete(message)}
+          {onForward}
         />
       {/snippet}
 

--- a/packages/app-lite/src/lib/components/chat/ForwardMessageModal.svelte
+++ b/packages/app-lite/src/lib/components/chat/ForwardMessageModal.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import { schemas } from "@roomy-space/sdk";
+  import ForwardMessageModal, {
+    type ForwardFetchState,
+    type ForwardTarget,
+  } from "@roomy/design/components/modals/ForwardMessageModal.svelte";
+  import { createSpaceMetadataQuery } from "$lib/queries/space-metadata";
+  import { forwardMessage } from "$lib/mutations/message";
+  import { toast } from "@foxui/core";
+
+  type SidebarChannel =
+    typeof schemas.queries.getSpaceMetadata.SidebarChannel.infer;
+
+  let {
+    open = $bindable(false),
+    spaceId,
+    fromRoomId,
+    messageId,
+  }: {
+    open: boolean;
+    spaceId: string;
+    /** The room the forwarded message currently lives in. */
+    fromRoomId: string;
+    messageId: string;
+  } = $props();
+
+  const metaQuery = createSpaceMetadataQuery(() => spaceId, {
+    enabled: open,
+  });
+
+  const targets = $derived.by<ForwardTarget[]>(() => {
+    const meta = metaQuery.data;
+    if (!meta) return [];
+
+    // Candidate targets: channels the user can write to (with their recently
+    // active threads), plus writable active threads of unreadable channels.
+    // Readable channels' threads render under the channel as "suggested".
+    const out: ForwardTarget[] = [];
+    const seen = new Set<string>();
+    const push = (id: string, name?: string) => {
+      if (seen.has(id)) return;
+      seen.add(id);
+      out.push({ id, name });
+    };
+
+    const pushChannel = (ch: SidebarChannel) => {
+      if (ch.canWrite) push(ch.id, ch.name);
+      for (const t of ch.activeThreads ?? []) {
+        if (t.canWrite) push(t.id, t.name);
+      }
+    };
+
+    for (const cat of meta.sidebar.categories) {
+      for (const ch of cat.channels) {
+        if (ch.canRead) {
+          pushChannel(ch);
+        } else {
+          for (const t of ch.activeThreads ?? []) {
+            if (t.canWrite) push(t.id, t.name);
+          }
+        }
+      }
+    }
+    for (const ch of meta.sidebar.orphans) {
+      if (ch.canRead) {
+        pushChannel(ch);
+      } else {
+        for (const t of ch.activeThreads ?? []) {
+          if (t.canWrite) push(t.id, t.name);
+        }
+      }
+    }
+    return out;
+  });
+
+  const fetchState = $derived.by((): ForwardFetchState => {
+    if (!open) return { status: "idle" };
+    if (metaQuery.isPending) return { status: "loading" };
+    if (metaQuery.isError)
+      return {
+        status: "error",
+        message:
+          metaQuery.error instanceof Error
+            ? metaQuery.error.message
+            : "Failed to load rooms",
+      };
+    const data = targets.filter((t) => t.id !== fromRoomId);
+    return { status: "success", data };
+  });
+
+  async function handleForward(roomId: string) {
+    await forwardMessage(spaceId, fromRoomId, messageId, roomId);
+    toast.success("Message forwarded");
+  }
+</script>
+<ForwardMessageModal bind:open {fetchState} onForward={handleForward} />

--- a/packages/app-lite/src/lib/components/chat/MessageToolbar.svelte
+++ b/packages/app-lite/src/lib/components/chat/MessageToolbar.svelte
@@ -11,6 +11,7 @@
     canEdit: boolean;
     canDelete: boolean;
     keepToolbarOpen?: boolean;
+    onForward: (message: Message) => void;
     onStartEdit: (messageId: string) => void;
     /** Requests the delete confirmation (owned by ChatArea). */
     onRequestDelete: () => void;
@@ -23,6 +24,7 @@
     canEdit,
     canDelete,
     keepToolbarOpen = $bindable(false),
+    onForward,
     onStartEdit,
     onRequestDelete,
   }: Props = $props();
@@ -57,4 +59,5 @@
   {onDelete}
   {onStartThreading}
   {onReply}
+  onForward={() => onForward(message)}
 />

--- a/packages/app-lite/src/lib/components/chat/MobileMessageDrawer.svelte
+++ b/packages/app-lite/src/lib/components/chat/MobileMessageDrawer.svelte
@@ -11,6 +11,7 @@
     open?: boolean;
     canEdit: boolean;
     canDelete: boolean;
+    onForward: (message: Message) => void;
     onStartEdit: (messageId: string) => void;
     /** Requests the delete confirmation (owned by ChatArea). */
     onRequestDelete: () => void;
@@ -23,6 +24,7 @@
     open = $bindable(false),
     canEdit,
     canDelete,
+    onForward,
     onStartEdit,
     onRequestDelete,
   }: Props = $props();
@@ -61,6 +63,7 @@
   {canDelete}
   {onToggleReaction}
   {onReply}
+  onForward={() => message && onForward(message)}
   {onStartThreading}
   {onEdit}
   {onDelete}

--- a/packages/app-lite/src/lib/mutations/message.ts
+++ b/packages/app-lite/src/lib/mutations/message.ts
@@ -89,3 +89,22 @@ export async function deleteMessage(
   await sendEvents(spaceId, [event]);
   return id;
 }
+
+export async function forwardMessage(
+  spaceId: string,
+  fromRoomId: string,
+  messageId: string,
+  toRoomId: string,
+): Promise<string> {
+  const id = newUlid();
+  const event: Record<string, unknown> = {
+    id,
+    room: toRoomId,
+    $type: "space.roomy.message.forwardMessages.v0",
+    messageIds: [messageId],
+    fromRoomId,
+  };
+
+  await sendEvents(spaceId, [event]);
+  return id;
+}

--- a/packages/design/src/components/content/thread/message/MessageDrawer.svelte
+++ b/packages/design/src/components/content/thread/message/MessageDrawer.svelte
@@ -5,6 +5,7 @@
   import {
     IconSmilePlus,
     IconReply,
+    IconForward,
     IconNeedleThread,
     IconEdit,
     IconTrash,
@@ -17,6 +18,7 @@
     canDelete,
     onToggleReaction,
     onReply,
+    onForward,
     onStartThreading,
     onEdit,
     onDelete,
@@ -30,6 +32,7 @@
     canDelete: boolean;
     onToggleReaction: (emoji: string) => void;
     onReply: () => void;
+    onForward: () => void;
     onStartThreading: () => void;
     onEdit: () => void;
     onDelete: () => void;
@@ -105,6 +108,16 @@
       >
         <IconReply />
         Reply
+      </Button>
+      <Button
+        onclick={() => {
+          onForward();
+          open = false;
+        }}
+        class="dz-join-item dz-btn w-full"
+      >
+        <IconForward />
+        Forward
       </Button>
       <Button
         onclick={() => {

--- a/packages/design/src/components/content/thread/message/ToolbarShell.svelte
+++ b/packages/design/src/components/content/thread/message/ToolbarShell.svelte
@@ -6,6 +6,7 @@
   import {
     IconSmilePlus,
     IconReply,
+    IconForward,
     IconNeedleThread,
     IconEdit,
     IconTrash,
@@ -20,6 +21,7 @@
     onDelete,
     onStartThreading,
     onReply,
+    onForward,
   }: {
     /** Author-only — shows the Edit button. */
     canEdit: boolean;
@@ -32,6 +34,7 @@
     onDelete: () => void;
     onStartThreading: () => void;
     onReply: () => void;
+    onForward: () => void;
   } = $props();
 
   let isEmojiToolbarPickerOpen = $state(false);
@@ -153,6 +156,19 @@
         aria-label="Reply"
       >
         <IconReply />
+      </Toolbar.Button>
+    </Tooltip>
+
+    <Tooltip tip="Forward">
+      <Toolbar.Button
+        onclick={onForward}
+        class={[
+          buttonVariants({ variant: "ghost", size: "icon" }),
+          "backdrop-blur-none h-[34px]",
+        ]}
+        aria-label="Forward"
+      >
+        <IconForward />
       </Toolbar.Button>
     </Tooltip>
   </Toolbar.Root>

--- a/packages/design/src/components/modals/ForwardMessageModal.svelte
+++ b/packages/design/src/components/modals/ForwardMessageModal.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+  import { Modal } from "@foxui/core";
+  import Input from "../ui/input/Input.svelte";
+  import Button from "../ui/button/Button.svelte";
+  import { IconHashtag, IconLoading } from "../../icons/index";
+  import ErrorMessage from "../helper/ErrorMessage.svelte";
+
+  export interface ForwardTarget {
+    id: string;
+    name?: string;
+  }
+
+  export type ForwardFetchState =
+    | { status: "idle" }
+    | { status: "loading" }
+    | { status: "error"; message: string }
+    | { status: "success"; data: ForwardTarget[] };
+
+  let {
+    open = $bindable(false),
+    fetchState,
+    onForward,
+  }: {
+    open: boolean;
+    fetchState: ForwardFetchState;
+    onForward: (roomId: string) => void | Promise<void>;
+  } = $props();
+
+  let query = $state("");
+  let forwarding = $state(false);
+  let errorMessage = $state<string | null>(null);
+
+  $effect(() => {
+    if (!open) {
+      query = "";
+      forwarding = false;
+      errorMessage = null;
+    }
+  });
+
+  const results = $derived.by<ForwardTarget[]>(() => {
+    if (fetchState.status !== "success") return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return fetchState.data;
+    return fetchState.data.filter(
+      (t) => t.name?.toLowerCase().includes(q) ?? false,
+    );
+  });
+
+  async function handleForward(target: ForwardTarget) {
+    if (forwarding) return;
+    forwarding = true;
+    errorMessage = null;
+    try {
+      await onForward(target.id);
+      open = false;
+    } catch (e) {
+      errorMessage = e instanceof Error ? e.message : "Failed to forward message";
+      forwarding = false;
+    }
+  }
+</script>
+
+<Modal bind:open>
+  <div class="flex flex-col gap-4">
+    <div>
+      <h3 class="text-base font-semibold text-base-900 dark:text-base-100">
+        Forward message
+      </h3>
+      <p class="text-sm text-base-500 dark:text-base-400">
+        Choose a room to forward this message to.
+      </p>
+    </div>
+
+    <Input
+      bind:value={query}
+      placeholder="Search rooms…"
+      aria-label="Search rooms"
+    />
+
+    {#if errorMessage}
+      <ErrorMessage message={errorMessage} />
+    {/if}
+
+    {#if fetchState.status === "loading"}
+      <div class="flex items-center justify-center gap-2 py-6 text-base-400">
+        <IconLoading class="size-4 animate-spin" />
+        <span class="text-sm">Loading rooms…</span>
+      </div>
+    {:else if fetchState.status === "error"}
+      <ErrorMessage message={fetchState.message} class="py-4 justify-center text-center" />
+    {:else if fetchState.status === "success"}
+      {#if results.length === 0}
+        <p class="text-sm text-base-400 dark:text-base-500 py-4 text-center">
+          No matching rooms.
+        </p>
+      {:else}
+        <ul class="flex flex-col gap-1 max-h-[40vh] overflow-y-auto">
+          {#each results as target (target.id)}
+            <li>
+              <Button
+                variant="ghost"
+                class="w-full justify-start gap-2 py-2 px-2 h-auto font-normal"
+                onclick={() => handleForward(target)}
+                disabled={forwarding}
+              >
+                <IconHashtag class="size-4 shrink-0 text-base-400" />
+                <span class="truncate text-sm text-base-800 dark:text-base-200">
+                  {target.name ?? "Unnamed room"}
+                </span>
+              </Button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    {/if}
+
+    <div class="flex justify-end">
+      <Button variant="primary" onclick={() => (open = false)}>Cancel</Button>
+    </div>
+  </div>
+</Modal>

--- a/packages/design/src/icons/index.ts
+++ b/packages/design/src/icons/index.ts
@@ -49,6 +49,7 @@ export { default as IconMessageCircleOff } from "~icons/ph/chat-circle-slash-bol
 export { default as IconMessageCirclePlus } from "~icons/ph/chat-circle-dots-bold";
 export { default as IconNeedleThread } from "~icons/tabler/needle-thread";
 export { default as IconReply } from "~icons/ph/arrow-bend-up-left-bold";
+export { default as IconForward } from "~icons/ph/arrow-bend-up-right-bold";
 
 // Status
 export { default as IconAlertCircle } from "~icons/ph/warning-circle-bold";


### PR DESCRIPTION
<img width="739" height="848" alt="Screenshot 2026-08-05 at 1 45 53 pm" src="https://github.com/user-attachments/assets/c46dcd66-4b3b-43d3-9817-2e032727173b" />

message forwarding is going to take a bit of work to get right. it's a pretty important feature and there are also a few of aspects to it that don't have all the groundwork done yet. 

in particular:
- forwards should really be treated as extensions/attachments/embeds to messages. this is necessary to do the feature on Discord where you can comment on what you're forwarding. this might make more sense to do after we move to structured rich text message representations.
- the schema change makes sense to do before updating the getMessages return type. currently it just shows forwarded messages as normal messages. it also orders them by when the original message was sent, rather than when the message was forwarded. we need to order them correctly and indicate that it was forwarded, and where from. (this might be added to the schema.)
  - side note: we also need an indication in the getMessages endpoint about whether a message was edited. edit history should ultimately be queryable by admins.
- we want to be able to forward messages between spaces that a user is a member of. this is essentially cross-space room search. so we need this endpoint.
- i think cross-space forwarding is fine to ship for now but flagging that there may be some privacy concerns. Discord essentially seems to strip the context and treat forwards as just a glorified quote. I think for Roomy we want a more dynamic sense of interconnection, but should users be able to opt out of having their messages be dynamically linked to them as author? (i think better to strip metadata in the opt-out case than to disable forwarding, since that encourages inaccessible screenshots) 