### PR TITLE
Fix mobile menu hiding messages

### DIFF
--- a/packages/app-lite/src/lib/components/layout/MainLayout.svelte
+++ b/packages/app-lite/src/lib/components/layout/MainLayout.svelte
@@ -81,7 +81,7 @@ let {
 <!-- Main panel: navbar + page content, offset to clear the fixed sidebar -->
 <div
   class={[
-    "h-full flex flex-col overflow-hidden main-panel bg-white dark:bg-base-950",
+    "h-screen flex flex-col overflow-hidden main-panel bg-white dark:bg-base-950",
     "sm:ml-64",
   ]}
   ontouchstart={handleTouchStart}


### PR DESCRIPTION
The issue is vaul-svelte manually sets the body element's height to `auto` without any prop to override that behavior. My fix was to make the main panel use h-screen instead of h-full so it uses the full screen's height independent of the body element's height.