### PR TITLE
Fix links at the end of messages not autolinking

### DIFF
--- a/packages/app-lite/src/lib/components/chat/ChatInput.svelte
+++ b/packages/app-lite/src/lib/components/chat/ChatInput.svelte
@@ -46,7 +46,7 @@
     mentionSearch?: (query: string) => Promise<TypeaheadUser[]>;
     /** Rooms in space that can be mentioned with #room */
     context?: Item[];
-    onEnter: (content: string, mentions: string[]) => Promise<void>;
+    onEnter: (content: string, mentions: string[], blocks: Block[]) => Promise<void>;
     placeholder?: string;
     setFocus?: boolean;
     disabled?: boolean;
@@ -70,9 +70,25 @@
 
   let tiptap: Editor | undefined = $state();
 
+  function flushTrailingAutolink() {
+    if (!tiptap || !tiptap.state.selection.empty) return;
+
+    const from = tiptap.state.selection.$from;
+    if (from.parentOffset !== from.parent.content.size) return;
+
+    const boundary = tiptap.state.selection.from;
+    tiptap.view.dispatch(tiptap.state.tr.insertText(" "));
+    return boundary;
+  }
+
   async function wrappedOnEnter() {
+    const boundary = flushTrailingAutolink();
     const mentions = tiptap ? extractMentionDids(tiptap) : [];
-    await onEnter(content, mentions);
+    const currentBlocks = tiptap ? proseMirrorDocToBlocks(tiptap.getJSON()) : (blocks ?? []);
+    if (boundary !== undefined) {
+      tiptap?.commands.deleteRange({ from: boundary, to: boundary + 1 });
+    }
+    await onEnter(content, mentions, currentBlocks);
   }
 
   /**

--- a/packages/app-lite/src/lib/components/chat/ChatInputArea.svelte
+++ b/packages/app-lite/src/lib/components/chat/ChatInputArea.svelte
@@ -290,7 +290,7 @@
     messagingState.setNormal();
   }
 
-  async function handleSend(_message = "", mentions: string[] = []) {
+  async function handleSend(_message = "", mentions: string[] = [], submittedBlocks: Block[] = []) {
     const state = messagingState.current;
     if (state.kind === "threading") return;
     if (!("input" in state)) return;
@@ -307,7 +307,7 @@
     // sidecar is dropped (mentions fold into `#didMention` facets). Until
     // the flag query has loaded, or when blocks are absent, the legacy
     // markdown path is used.
-    const useRichText = richtextEnabled && !!blocks && blocks.length > 0;
+    const useRichText = richtextEnabled && !!submittedBlocks && submittedBlocks.length > 0;
 
     try {
       const attachments: Record<string, unknown>[] = [];
@@ -357,7 +357,7 @@
                 mimeType: "application/vnd.roomy.richtext+json",
                 data: toBytes(new TextEncoder().encode(JSON.stringify({
                   $type: "space.roomy.richtext.document",
-                  blocks: blocks!,
+                  blocks: submittedBlocks,
                 }))),
               }
             : {
@@ -372,7 +372,7 @@
           replyTo:
             state.kind === "replying" ? state.replyTo.id : undefined,
           mentions,
-          ...(useRichText ? { blocks } : {}),
+          ...(useRichText ? { blocks: submittedBlocks } : {}),
         });
       }
     } catch (e: unknown) {

--- a/packages/app-lite/src/lib/components/chat/ChatMessage.svelte
+++ b/packages/app-lite/src/lib/components/chat/ChatMessage.svelte
@@ -107,7 +107,7 @@
   }
 
 
-  async function handleEdit(newContent: string, _mentions: string[]) {
+  async function handleEdit(newContent: string, _mentions: string[], submittedBlocks: Block[]) {
     const isRichText = message.mimeType === RICHTEXT_MIME;
     if (!isRichText && newContent === message.content) {
       onCancelEdit();
@@ -120,7 +120,7 @@
       newContent,
       // Rich-text messages stay rich-text: send the blocks (which ChatInput
       // keeps in sync) rather than the base64-encoded wire body or markdown.
-      isRichText ? { blocks: editBlocks ?? [] } : {},
+      isRichText ? { blocks: submittedBlocks } : {},
     );
     onCancelEdit();
   }


### PR DESCRIPTION
Introduces a new param to onEnter for the current blocks, which is updated right before sending to run through autolinking by adding a space, then removing it.