### PR TITLE
Fix editLinks being written inside an effect that reads from it

### DIFF
--- a/packages/app-lite/src/lib/components/chat/ChatMessage.svelte
+++ b/packages/app-lite/src/lib/components/chat/ChatMessage.svelte
@@ -128,11 +128,15 @@
   // dismissed before editing began).
   $effect(() => {
     const urls = editUrls;
-    editLinks = editLinks.filter((l) => urls.includes(l.url));
+    const current = editLinks;
+    const next = current.filter((l) => urls.includes(l.url));
     for (const url of urls) {
-      if (!editLinks.some((l) => l.url === url)) {
-        editLinks = [...editLinks, { url, embed: null, showPreview: !initialDismissed.has(url) }];
+      if (!next.some((l) => l.url === url)) {
+        next.push({ url, embed: null, showPreview: !initialDismissed.has(url) });
       }
+    }
+    if (next.length !== current.length || next.some((link, i) => link !== current[i])) {
+      editLinks = next;
     }
   });
   // Best-effort fetch of embed metadata for each preview (guarded so a URL is


### PR DESCRIPTION
Now it only gets written when its actually changed, which will then only trigger a single extra effect call. The effect is still reactive to changes to editUrls and editLinks