### PR TITLE
fix android UI overlapping interactive elements

### DIFF
--- a/packages/app-lite/src/app.html
+++ b/packages/app-lite/src/app.html
@@ -81,6 +81,6 @@
     </script>
   </head>
   <body data-sveltekit-preload-data="hover" class="bg-base-50 dark:bg-base-950">
-    <div style="display: contents; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom);">%sveltekit.body%</div>
+    <div style="display: contents; padding-top: env(safe-area-inset-top);">%sveltekit.body%</div>
   </body>
 </html>

--- a/packages/app-lite/src/app.html
+++ b/packages/app-lite/src/app.html
@@ -81,6 +81,6 @@
     </script>
   </head>
   <body data-sveltekit-preload-data="hover" class="bg-base-50 dark:bg-base-950">
-    <div style="display: contents">%sveltekit.body%</div>
+    <div style="display: contents; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom);">%sveltekit.body%</div>
   </body>
 </html>

--- a/packages/app-lite/src/lib/components/sidebar/SidebarUserCard.svelte
+++ b/packages/app-lite/src/lib/components/sidebar/SidebarUserCard.svelte
@@ -60,7 +60,7 @@
 
 <div class="shrink-0 px-2 pb-2 pt-1">
   <div
-    class="flex items-center gap-3 w-full rounded-lg px-3 py-2 bg-white dark:bg-base-950 border border-base-500/20"
+    class="flex items-center gap-3 w-full rounded-lg px-3 py-2 bg-white dark:bg-base-950 border border-base-500/20 mb-[env(safe-area-inset-bottom)]"
   >
     <div class="relative size-10 shrink-0">
       <div class="size-full rounded-full overflow-hidden">

--- a/packages/design/src/components/content/thread/ChatInputShell.svelte
+++ b/packages/design/src/components/content/thread/ChatInputShell.svelte
@@ -107,7 +107,7 @@
   });
 </script>
 
-<div class="flex-none pt-2 pb-2 pr-2">
+<div class="flex-none pt-2 pb-[calc(0.5rem + env(safe-area-inset-bottom))] pr-2">
   {#if showContextPreview}
     <div
       class="flex justify-between bg-secondary text-secondary-content rounded-t-lg p-2 gap-2 pr-0"

--- a/packages/design/src/components/content/thread/ChatInputShell.svelte
+++ b/packages/design/src/components/content/thread/ChatInputShell.svelte
@@ -107,7 +107,7 @@
   });
 </script>
 
-<div class="flex-none pt-2 pb-[calc(0.5rem + env(safe-area-inset-bottom))] pr-2">
+<div class="flex-none pt-2 pb-[calc(--spacing(2)_+_env(safe-area-inset-bottom))] pr-2">
   {#if showContextPreview}
     <div
       class="flex justify-between bg-secondary text-secondary-content rounded-t-lg p-2 gap-2 pr-0"


### PR DESCRIPTION
Fixes most* cases of OS UI obscuring Roomy on android (issue #660), by applying `env(safe-area-inset-[top|bottom]` to the body element (top), ChatInput (bottom), and ProfileCard (bottom). May also fix a similar issue that was reported for PWAs. On platfroms where the env value is unset it defaults to 0 and will not affect any existing style.

*There's been some cases with height overlapping the nav I couldn't reproduce. Hopefully those also get fixed, otherwise I'll be back to try and find a more granular top padding target.