### PR TITLE
fix(design): share thin scrollbar styling via a scrollbar utility class

### DIFF
--- a/packages/app-lite/src/app.css
+++ b/packages/app-lite/src/app.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 @import "./fonts-hanken-grotesk.css";
+@import "@roomy/design/scrollbar.css";
 
 @source "../node_modules/@roomy/design";
 @source "../node_modules/@foxui";

--- a/packages/app-lite/src/lib/components/sidebar/SpaceSidebar.svelte
+++ b/packages/app-lite/src/lib/components/sidebar/SpaceSidebar.svelte
@@ -753,7 +753,7 @@
 
   {#snippet overlayBody()}
     <div
-      class="flex flex-col h-full w-full px-2 pt-3 pb-4 overflow-y-auto bg-base-50 dark:bg-base-950 mask-[linear-gradient(to_bottom,transparent_0%,black_2%,black_95%,transparent_100%)]"
+      class="flex flex-col h-full w-full px-2 pt-3 pb-4 overflow-y-auto scrollbar bg-base-50 dark:bg-base-950 mask-[linear-gradient(to_bottom,transparent_0%,black_2%,black_95%,transparent_100%)]"
     >
       <!-- Settings pages -->
       <div class="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wider text-base-400 dark:text-base-500">

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -9,6 +9,7 @@
     },
     "./icons": "./src/icons/index.ts",
     "./icons/*": "./src/icons/*",
+    "./scrollbar.css": "./src/scrollbar.css",
     "./utils": "./src/utils/index.ts",
     "./utils/*": "./src/utils/*",
     "./components/*": "./src/components/*"

--- a/packages/design/src/components/layout/ScrollArea.svelte
+++ b/packages/design/src/components/layout/ScrollArea.svelte
@@ -35,46 +35,4 @@
   {@render children?.()}
 </div>
 
-<style>
-  .scrollbar::-webkit-scrollbar-track {
-    background-color: transparent;
-  }
-
-  @supports (scrollbar-width: auto) {
-    .scrollbar {
-      scrollbar-color: var(--color-base-400) transparent;
-      scrollbar-width: thin;
-    }
-
-    :global(.dark .scrollbar) {
-      scrollbar-color: var(--color-base-800) transparent;
-    }
-  }
-
-  @supports not (scrollbar-width: auto) {
-    :global(.scrollbar::-webkit-scrollbar) {
-      width: 14px;
-      height: 14px;
-    }
-  }
-
-  .scrollbar::-webkit-scrollbar-thumb {
-    background-color: var(--color-base-400);
-    border-radius: 20px;
-    border: 4px solid transparent;
-    background-clip: content-box;
-  }
-
-  .scrollbar::-webkit-scrollbar-thumb:hover {
-    background-color: var(--color-base-500);
-  }
-
-  /* Dark mode rules */
-  :global(.dark .scrollbar::-webkit-scrollbar-thumb) {
-    background-color: var(--color-base-800);
-  }
-
-  :global(.dark .scrollbar::-webkit-scrollbar-thumb:hover) {
-    background-color: var(--color-base-700);
-  }
-</style>
+<!-- Scrollbar styling comes from the shared `.scrollbar` class (src/scrollbar.css). -->

--- a/packages/design/src/components/sidebars/SidebarLayout.svelte
+++ b/packages/design/src/components/sidebars/SidebarLayout.svelte
@@ -62,7 +62,7 @@
 
   <div class="relative flex-1 min-h-0 flex flex-col overflow-hidden sidebar-body-wrap">
     <div
-      class="w-full h-full px-2 pt-3 pb-20 mask-[linear-gradient(to_bottom,transparent_0%,black_2%,black_95%,transparent_100%)] flex-1 min-h-0 overflow-y-scroll sidebar-body-slide"
+      class="w-full h-full px-2 pt-3 pb-20 mask-[linear-gradient(to_bottom,transparent_0%,black_2%,black_95%,transparent_100%)] flex-1 min-h-0 overflow-y-scroll scrollbar sidebar-body-slide"
       class:sidebar-body-slide-out={bodySlideOut}
     >
       {#if prefix}{@render prefix?.()}{/if}

--- a/packages/design/src/scrollbar.css
+++ b/packages/design/src/scrollbar.css
@@ -1,0 +1,41 @@
+/* Thin themed scrollbar. Apply `.scrollbar` to any scroll container. */
+.scrollbar::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+@supports (scrollbar-width: auto) {
+  .scrollbar {
+    scrollbar-color: var(--color-base-400) transparent;
+    scrollbar-width: thin;
+  }
+
+  .dark .scrollbar {
+    scrollbar-color: var(--color-base-800) transparent;
+  }
+}
+
+@supports not (scrollbar-width: auto) {
+  .scrollbar::-webkit-scrollbar {
+    width: 14px;
+    height: 14px;
+  }
+}
+
+.scrollbar::-webkit-scrollbar-thumb {
+  background-color: var(--color-base-400);
+  border-radius: 20px;
+  border: 4px solid transparent;
+  background-clip: content-box;
+}
+
+.scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-base-500);
+}
+
+.dark .scrollbar::-webkit-scrollbar-thumb {
+  background-color: var(--color-base-800);
+}
+
+.dark .scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-base-700);
+}

--- a/packages/design/src/storybook.css
+++ b/packages/design/src/storybook.css
@@ -14,6 +14,7 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 @import "@fontsource-variable/inter";
+@import "./scrollbar.css";
 
 @source "./components";
 @source "./icons";


### PR DESCRIPTION
In order to avoid:
<img width="1200" height="500" alt="image" src="https://github.com/user-attachments/assets/e2dd400c-22d7-4a0b-9b60-bcf9b392166f" />

It would be nice to have a shared `scrollbar`

WDYT?